### PR TITLE
Add tox to requirements.txt & PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### Description:
+
+Add description here.
+
+### Potential Impact:
+
+List potential impact to downstream libraries here (ex. atlas-checks, atlas-generator)
+
+### Unit Test Approach:
+
+Describe unit tests being added with that PR.
+
+### Test Results:
+
+Describe other (non-unit) test results here.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-requests
+requests==2.23.0
+tox==3.14.5


### PR DESCRIPTION
- This adds the tox library to requirements.txt. Tox is used as a unit test runner and is trigger on every travis build. This should fix [our latest travis-ci build failure](https://travis-ci.com/osmlab/maproulette-python-client)
- I also added a PR template