### PR TITLE
[Travis] Set tox python version to 3.6

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37
+envlist = py36
 
 [testenv]
 deps =


### PR DESCRIPTION
### Description:

Setting the tox python version to match travis. This should fix - https://travis-ci.com/osmlab/maproulette-python-client/jobs/294123139

### Potential Impact:

No impact 

### Unit Test Approach:

Will test after merge

### Test Results:

This should pass travis after merge
