### PR TITLE
[CI] PyPi publish on release

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -3,6 +3,8 @@ name: Publish Python 🐍 distributions 📦 to PyPI
 on:
   release:
     types: [created]
+    branches:
+      - master
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,6 +1,8 @@
 name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
 
-on: push
+on:
+  release:
+    types: [created]
 
 jobs:
   build-n-publish:
@@ -29,5 +31,5 @@ jobs:
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
-          password: ${{ secrets.pypi_token_test }}
+          password: ${{ secrets.test_pypi_password }}
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -29,5 +29,5 @@ jobs:
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
-          password: ${{ secrets.test_pypi_password }}
+          password: ${{ secrets.pypi_token_test }}
           repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -1,4 +1,4 @@
-name: Publish Python 🐍 distributions 📦 to PyPI and TestPyPI
+name: Publish Python 🐍 distributions 📦 to PyPI
 
 on:
   release:
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build-n-publish:
-    name: Build and publish Python distributions to PyPI and TestPyPI
+    name: Build and publish Python distributions to PyPI
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
@@ -28,9 +28,8 @@ jobs:
           --binary
           --out-dir dist/
           .
-      - name: Publish distribution to Test PyPI
+      - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
           user: __token__
-          password: ${{ secrets.test_pypi_password }}
-          repository_url: https://test.pypi.org/legacy/
+          password: ${{ secrets.pypi_password }}

--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -31,5 +31,6 @@ jobs:
       - name: Publish distribution to Test PyPI
         uses: pypa/gh-action-pypi-publish@master
         with:
+          user: __token__
           password: ${{ secrets.test_pypi_password }}
           repository_url: https://test.pypi.org/legacy/

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as readme:
     long_description = readme.read()
 
 setup(name="maproulette",
-      version="1.0.0-alpha.2",
+      version="1.0.0-alpha.3",
       description="A Python API wrapper for MapRoulette",
       long_description=long_description,
       url="https://github.com/osmlab/maproulette-python-client",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as readme:
     long_description = readme.read()
 
 setup(name="maproulette",
-      version="0.0.1",
+      version="1.0.0-alpha.1",
       description="A Python API wrapper for MapRoulette",
       long_description=long_description,
       url="https://github.com/osmlab/maproulette-python-client",

--- a/setup.py
+++ b/setup.py
@@ -6,11 +6,11 @@ with open("README.md", "r") as readme:
 setup(name="maproulette",
       version="0.0.1",
       description="A Python API wrapper for MapRoulette",
+      license="Apache License 2.0",
       long_description=long_description,
       url="https://github.com/osmlab/maproulette-python-client",
-      packages=find_packages('maproulette'),
+      packages=find_packages(exclude=["tests", "examples"]),
       python_requires='>=3.6',
       setup_requires=["pytest-runner"],
       tests_require=["pytest"],
-      package_dir={'': 'maproulette'},
       install_requires=['requests'])

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as readme:
     long_description = readme.read()
 
 setup(name="maproulette",
-      version="0.0.1",
+      version="1.0.0-alpha.4",
       description="A Python API wrapper for MapRoulette",
       license="Apache License 2.0",
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as readme:
     long_description = readme.read()
 
 setup(name="maproulette",
-      version="1.0.0-alpha.1",
+      version="1.0.0-alpha.2",
       description="A Python API wrapper for MapRoulette",
       long_description=long_description,
       url="https://github.com/osmlab/maproulette-python-client",

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as readme:
     long_description = readme.read()
 
 setup(name="maproulette",
-      version="1.0.0-alpha.4",
+      version="0.0.1",
       description="A Python API wrapper for MapRoulette",
       license="Apache License 2.0",
       long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as readme:
     long_description = readme.read()
 
 setup(name="maproulette",
-      version="1.0.0-alpha.3",
+      version="0.0.1",
       description="A Python API wrapper for MapRoulette",
       long_description=long_description,
       url="https://github.com/osmlab/maproulette-python-client",


### PR DESCRIPTION
### Description:

This updates the publish workflow to trigger every tag release.
The workflow for pushing a release to pypi is:
 1. merge dev changes to master branch
 2. create a [tag release](https://github.com/osmlab/maproulette-python-client/releases/new) targeting the `master` branch

### Potential Impact:

No downstream impact.

### Unit Test Approach:

No unit tests

### Test Results:

Created a release on my fork: https://github.com/danielduhh/maproulette-python-client/releases/tag/1.0.0-alpha.4

This triggered the following workflow:
https://github.com/danielduhh/maproulette-python-client/actions/runs/70235647

Ran successful
<img width="1440" alt="Screen Shot 2020-04-03 at 4 26 00 PM" src="https://user-images.githubusercontent.com/1947857/78412334-d1fa3980-75c7-11ea-8d81-5c449b1e03bb.png">

And published to test pypi
https://test.pypi.org/project/maproulette/1.0.0a4/#files