### PR TITLE
Add functionality for client-side certs

### DIFF
--- a/docs/usage/functionality.rst
+++ b/docs/usage/functionality.rst
@@ -27,4 +27,4 @@ Module: configuration
 
 .. automodule:: maproulette.api.configuration
     :members:
-    :show-inheritance:
+    :special-members:

--- a/docs/usage/getting_started.rst
+++ b/docs/usage/getting_started.rst
@@ -14,8 +14,9 @@ Import the package:
     import maproulette
 
 
-From there, create a configuration object. Depending on your use case, you may need to pass your API key. Specify
-that when you create your configuration. For example:
+From there, create a configuration object. When creating the configuration you can specify a number of of parameters
+depending on your needs including the hostname, protocol, and client-side certificates. Depending on your use case, you
+may need to obtain and pass your API key as well. For example:
 
 .. code-block:: python
 

--- a/maproulette/api/configuration.py
+++ b/maproulette/api/configuration.py
@@ -1,15 +1,37 @@
 """This module contains the basic configuration object that is used to communicate with the MapRoulette API."""
 
-DEFAULT_URL = 'maproulette.org'
+DEFAULT_HOSTNAME = 'maproulette.org'
 DEFAULT_PROTOCOL = 'https'
 DEFAULT_API_VERSION = '/api/v2'
 
 
 class Configuration:
     """Class for storing the configuration of the MapRoulette server"""
-    def __init__(self, url=DEFAULT_URL, protocol=DEFAULT_PROTOCOL, api_version=DEFAULT_API_VERSION, api_key=None):
-        self.url = f"{protocol}://{url}{api_version}"
-        self.base_url = f"{protocol}://{url}"
+    def __init__(self, hostname=DEFAULT_HOSTNAME, protocol=DEFAULT_PROTOCOL, api_version=DEFAULT_API_VERSION,
+                 api_key=None, certs=None, verify=True):
+        """Create a new configuration object to connect to the MapRoulette server.
+
+        :param hostname: Optional parameter to specify the hostname of the MapRoulette instance being addressed. Do not
+        include the protocol (https, http). Default value is 'maproulette.org'.
+        :type hostname: str
+        :param protocol: Optional parameter to specify the protocol to use for the connection to the MapRoulette
+        instance being addressed such as https or http. Default value is 'https'.
+        :type protocol: str
+        :param api_version: Optional parameter to specify the API version to use. The default is '/api/v2'.
+        :type api_version: str
+        :param api_key: Optional parameter to pass the user-specific API key. This key is necessary for some actions.
+        :type api_key: str
+        :param certs: Optional parameter to pass the client-side certificate and key if necessary to make connection
+        with the MapRoulette instance being addressed.
+        :type certs: tuple
+        :param verify: Optional parameter to specify whether to verify SSL certificates for HTTPS requests. Default is
+        True.
+        :type verify: bool
+        """
+        self.api_url = f"{protocol}://{hostname}{api_version}"
+        self.base_url = f"{protocol}://{hostname}"
+        self.protocol = protocol
         self.headers = dict()
         self.headers['apikey'] = api_key
-        self.protocol = protocol
+        self.certs = certs
+        self.verify = verify

--- a/maproulette/api/configuration.py
+++ b/maproulette/api/configuration.py
@@ -1,5 +1,7 @@
 """This module contains the basic configuration object that is used to communicate with the MapRoulette API."""
 
+from typing import Union
+
 DEFAULT_HOSTNAME = 'maproulette.org'
 DEFAULT_PROTOCOL = 'https'
 DEFAULT_API_VERSION = '/api/v2'
@@ -11,17 +13,24 @@ class Configuration:
                  api_key=None, certs=None, verify=True):
         """Create a new configuration object to connect to the MapRoulette server.
 
-        :param str hostname: Optional parameter to specify the hostname of the MapRoulette instance being addressed. Do
+        :param hostname: Optional parameter to specify the hostname of the MapRoulette instance being addressed. Do
             not include the protocol (https, http). Default value is 'maproulette.org'.
-        :param str protocol: Optional parameter to specify the protocol to use for the connection to the MapRoulette
+        :type hostname: str, optional
+        :param protocol: Optional parameter to specify the protocol to use for the connection to the MapRoulette
             instance being addressed such as https or http. Default value is 'https'.
-        :param str api_version: Optional parameter to specify the API version to use. The default is '/api/v2'.
-        :param str api_key: Optional parameter to pass the user-specific API key. This key is necessary for some
-            actions.
-        :param tuple certs: Optional parameter to pass the client-side certificate and key if necessary to make
-            connection with the MapRoulette instance being addressed.
-        :param bool verify: Optional parameter to specify whether to verify SSL certificates for HTTPS requests. Default
+        :type protocol: str, optional
+        :param api_version: Optional parameter to specify the API version to use. The default is '/api/v2'.
+        :type api_version: str, optional
+        :param api_key: Optional parameter to pass the user-specific API key. This key is necessary for some actions.
+        :type api_key: str, optional
+        :param certs: Optional parameter to pass the client-side certificate and key if necessary to make
+            connection with the MapRoulette instance being addressed. Can be either a tuple containing the cert and key
+            file paths (in that order) or a string representing the filepath to both the cert and key stored in a single
+            file.
+        :type certs: str or tuple, optional
+        :param verify: Optional parameter to specify whether to verify SSL certificates for HTTPS requests. Default
             is True.
+        :type verify: bool, optional
         """
         self.api_url = f"{protocol}://{hostname}{api_version}"
         self.base_url = f"{protocol}://{hostname}"

--- a/maproulette/api/configuration.py
+++ b/maproulette/api/configuration.py
@@ -11,22 +11,17 @@ class Configuration:
                  api_key=None, certs=None, verify=True):
         """Create a new configuration object to connect to the MapRoulette server.
 
-        :param hostname: Optional parameter to specify the hostname of the MapRoulette instance being addressed. Do not
-        include the protocol (https, http). Default value is 'maproulette.org'.
-        :type hostname: str
-        :param protocol: Optional parameter to specify the protocol to use for the connection to the MapRoulette
-        instance being addressed such as https or http. Default value is 'https'.
-        :type protocol: str
-        :param api_version: Optional parameter to specify the API version to use. The default is '/api/v2'.
-        :type api_version: str
-        :param api_key: Optional parameter to pass the user-specific API key. This key is necessary for some actions.
-        :type api_key: str
-        :param certs: Optional parameter to pass the client-side certificate and key if necessary to make connection
-        with the MapRoulette instance being addressed.
-        :type certs: tuple
-        :param verify: Optional parameter to specify whether to verify SSL certificates for HTTPS requests. Default is
-        True.
-        :type verify: bool
+        :param str hostname: Optional parameter to specify the hostname of the MapRoulette instance being addressed. Do
+            not include the protocol (https, http). Default value is 'maproulette.org'.
+        :param str protocol: Optional parameter to specify the protocol to use for the connection to the MapRoulette
+            instance being addressed such as https or http. Default value is 'https'.
+        :param str api_version: Optional parameter to specify the API version to use. The default is '/api/v2'.
+        :param str api_key: Optional parameter to pass the user-specific API key. This key is necessary for some
+            actions.
+        :param tuple certs: Optional parameter to pass the client-side certificate and key if necessary to make
+            connection with the MapRoulette instance being addressed.
+        :param bool verify: Optional parameter to specify whether to verify SSL certificates for HTTPS requests. Default
+            is True.
         """
         self.api_url = f"{protocol}://{hostname}{api_version}"
         self.base_url = f"{protocol}://{hostname}"

--- a/maproulette/api/maproulette_server.py
+++ b/maproulette/api/maproulette_server.py
@@ -10,13 +10,16 @@ from .errors import HttpError, InvalidJsonError, ConnectionUnavailableError, Una
 class MapRouletteServer:
     """Class that holds the basic requests that can be made to the MapRoulette API."""
     def __init__(self, configuration):
-        self.url = configuration.url
+        self.url = configuration.api_url
         self.base_url = configuration.base_url
         self.headers = configuration.headers
+        self.certs = configuration.certs
+        self.verify = configuration.verify
         if self.__check_health():
             self.session = requests.Session()
             self.session.headers = self.headers
-            self.session.verify = False
+            self.session.verify = self.verify
+            self.session.cert = self.certs
 
     def __check_health(self, retries=3, delay=5):
         """Checks health of connection to host by pinging the URL set in the configuration
@@ -30,7 +33,8 @@ class MapRouletteServer:
                 response = requests.get(
                     self.base_url + '/ping',
                     headers=self.headers,
-                    verify=False
+                    verify=self.verify,
+                    cert=self.certs
                 )
                 if not response.ok:
                     print(f"Unsuccessful connection. Retrying in {str(delay)} seconds")

--- a/maproulette/api/project.py
+++ b/maproulette/api/project.py
@@ -1,6 +1,5 @@
 """This module contains the methods that the user will use directly to interact with MapRoulette projects"""
 
-import json
 from maproulette.api.maproulette_server import MapRouletteServer
 from maproulette.models.project import ProjectModel
 


### PR DESCRIPTION
### Description:
This PR adds the ability to specify client-side certs when creating the configuration object. This will allow users to specify a MapRoulette instance that requires them. The package expects the certs to be passed as a tuple containing the cert and key file paths, respectively. If a certs argument is not passed when creating the configuration object it will not be used when making requests to the server. The current way this works is as follows:

```python
import maproulette

# Path to your cert file
my_cert_file = '/path/to/my/cert/file'
# Path to your key file
my_key_file = '/path/to/my/key/file'
# Store both in a tuple
my_certs = (my_cert_file, my_key_file)
# Pass that tuple as the certs parameter when creating the config object
config = maproulette.Configuration(certs=mycerts)
```

While I was at it, I also renamed some variables in the configuration class to make them more explicit as to what they actually do. I also added a docstring to the configuration class constructor.
Finally, I added the "verify" parameter that can be passed when creating a configuration as well. This controls whether the Requests library should verify SSL certificates for HTTPS requests. The default is True.

### Potential Impact:
Allows users to specify client-side certs. 

### Unit Test Approach:
N/A

### Test Results:
N/A
