### PR TITLE
Add priority rule model

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Welcome to MapRoulette's documentation!
    usage/models/project
    usage/models/challenge
    usage/models/task
+   usage/models/priority_rule
    usage/exceptions
 
 ---------------

--- a/docs/usage/models/priority_rule.rst
+++ b/docs/usage/models/priority_rule.rst
@@ -1,8 +1,27 @@
 Priority Rule Model
 =====================================================
 
-.. automodule:: maproulette.models.priority_rule
+.. autoclass:: maproulette.models.priority_rule.PriorityRule
+    :members:
+
+.. autoclass:: maproulette.models.priority_rule.PriorityRuleModel
+    :members:
+
+.. autoclass:: maproulette.models.priority_rule.Conditions
+    :members:
+
+.. autoclass:: maproulette.models.priority_rule.Types
     :members:
     :undoc-members:
-    :inherited-members:
-    :show-inheritance:
+
+.. autoclass:: maproulette.models.priority_rule.Conditions
+    :members:
+    :undoc-members:
+
+.. autoclass:: maproulette.models.priority_rule.StringOperators
+    :members:
+    :undoc-members:
+
+.. autoclass:: maproulette.models.priority_rule.NumericOperators
+    :members:
+    :undoc-members:

--- a/docs/usage/models/priority_rule.rst
+++ b/docs/usage/models/priority_rule.rst
@@ -1,0 +1,8 @@
+Priority Rule Model
+=====================================================
+
+.. automodule:: maproulette.models.priority_rule
+    :members:
+    :undoc-members:
+    :inherited-members:
+    :show-inheritance:

--- a/examples/create_challenge_from_model.py
+++ b/examples/create_challenge_from_model.py
@@ -18,11 +18,11 @@ challenge_data.instruction = "Do something"
 
 # Let's create a basic rule to classify features with tags 'highway' = 'footway' to be high priority
 rule_1 = maproulette.PriorityRule(priority_value='highway.footway',
-                                  priority_type=maproulette.Types.STRING,
-                                  priority_operator=maproulette.StringOperators.EQUAL)
+                                  priority_type=maproulette.priority_rule.Types.STRING,
+                                  priority_operator=maproulette.priority_rule.StringOperators.EQUAL)
 
 # Create a formal priority rule for the challenge
-challenge_data.high_priority_rule = maproulette.PriorityRuleModel(condition=maproulette.Conditions.OR,
+challenge_data.high_priority_rule = maproulette.PriorityRuleModel(condition=maproulette.priority_rule.Conditions.OR,
                                                                   rules=rule_1
                                                                   ).to_json()
 

--- a/examples/create_challenge_from_model.py
+++ b/examples/create_challenge_from_model.py
@@ -17,10 +17,14 @@ challenge_data.description = "This is a test challenge"
 challenge_data.instruction = "Do something"
 
 # Let's create a basic rule to classify features with tags 'highway' = 'footway' to be high priority
-rule_1 = maproulette.PriorityRule(priority_value='highway.footway', priority_type='string', priority_operator='equal')
+rule_1 = maproulette.PriorityRule(priority_value='highway.footway',
+                                  priority_type=maproulette.Types.STRING,
+                                  priority_operator=maproulette.StringOperators.EQUAL)
 
 # Create a formal priority rule for the challenge
-challenge_data.high_priority_rule = maproulette.PriorityRuleModel(condition='OR', rules=rule_1).to_json()
+challenge_data.high_priority_rule = maproulette.PriorityRuleModel(condition=maproulette.Conditions.OR,
+                                                                  rules=rule_1
+                                                                  ).to_json()
 
 # Adding example overpass QL input for challenge
 challenge_data.overpassQL = open('data/Example_OverpassQL_Query', 'r').read()

--- a/examples/create_challenge_from_model.py
+++ b/examples/create_challenge_from_model.py
@@ -2,8 +2,7 @@ import maproulette
 import json
 
 # Create a configuration object for MapRoulette using your API key:
-config = maproulette.Configuration(api_key="2909|40fee283-0d8c-4b9d-ae4a-28850c132e66",
-                                   verify=False)
+config = maproulette.Configuration()
 
 # Create an API objects with the above config object:
 api = maproulette.Challenge(config)
@@ -25,6 +24,8 @@ challenge_data.high_priority_rule = maproulette.PriorityRuleModel(condition='OR'
 
 # Adding example overpass QL input for challenge
 challenge_data.overpassQL = open('data/Example_OverpassQL_Query', 'r').read()
+
+print(challenge_data.overpassQL)
 
 # Create challenge
 print(json.dumps(api.create_challenge(challenge_data)))

--- a/examples/create_challenge_from_model.py
+++ b/examples/create_challenge_from_model.py
@@ -2,7 +2,7 @@ import maproulette
 import json
 
 # Create a configuration object for MapRoulette using your API key:
-config = maproulette.Configuration()
+config = maproulette.Configuration(api_key="API_KEY")
 
 # Create an API objects with the above config object:
 api = maproulette.Challenge(config)

--- a/examples/create_challenge_from_model.py
+++ b/examples/create_challenge_from_model.py
@@ -2,7 +2,8 @@ import maproulette
 import json
 
 # Create a configuration object for MapRoulette using your API key:
-config = maproulette.Configuration(api_key="API_KEY")
+config = maproulette.Configuration(api_key="2909|40fee283-0d8c-4b9d-ae4a-28850c132e66",
+                                   verify=False)
 
 # Create an API objects with the above config object:
 api = maproulette.Challenge(config)
@@ -16,10 +17,14 @@ challenge_data.description = "This is a test challenge"
 # Adding required instruction
 challenge_data.instruction = "Do something"
 
+# Let's create a basic rule to classify features with tags 'highway' = 'footway' to be high priority
+rule_1 = maproulette.PriorityRule(priority_value='highway.footway', priority_type='string', priority_operator='equal')
+
+# Create a formal priority rule for the challenge
+challenge_data.high_priority_rule = maproulette.PriorityRuleModel(condition='OR', rules=[rule_1]).to_json()
+
 # Adding example overpass QL input for challenge
 challenge_data.overpassQL = open('data/Example_OverpassQL_Query', 'r').read()
-
-print(challenge_data.overpassQL)
 
 # Create challenge
 print(json.dumps(api.create_challenge(challenge_data)))

--- a/examples/create_challenge_from_model.py
+++ b/examples/create_challenge_from_model.py
@@ -20,7 +20,7 @@ challenge_data.instruction = "Do something"
 rule_1 = maproulette.PriorityRule(priority_value='highway.footway', priority_type='string', priority_operator='equal')
 
 # Create a formal priority rule for the challenge
-challenge_data.high_priority_rule = maproulette.PriorityRuleModel(condition='OR', rules=[rule_1]).to_json()
+challenge_data.high_priority_rule = maproulette.PriorityRuleModel(condition='OR', rules=rule_1).to_json()
 
 # Adding example overpass QL input for challenge
 challenge_data.overpassQL = open('data/Example_OverpassQL_Query', 'r').read()

--- a/maproulette/__init__.py
+++ b/maproulette/__init__.py
@@ -7,8 +7,7 @@ from .api.configuration import Configuration
 from .models.project import ProjectModel
 from .models.challenge import ChallengeModel
 from .models.task import TaskModel
-from .models.priority_rule import PriorityRuleModel
-from .models.priority_rule import PriorityRule
+from .models.priority_rule import *
 from .api.project import Project
 from .api.challenge import Challenge
 from .api.task import Task

--- a/maproulette/__init__.py
+++ b/maproulette/__init__.py
@@ -8,6 +8,7 @@ from .models.project import ProjectModel
 from .models.challenge import ChallengeModel
 from .models.task import TaskModel
 from .models.priority_rule import PriorityRuleModel
+from .models.priority_rule import PriorityRule
 from .api.project import Project
 from .api.challenge import Challenge
 from .api.task import Task

--- a/maproulette/__init__.py
+++ b/maproulette/__init__.py
@@ -7,6 +7,7 @@ from .api.configuration import Configuration
 from .models.project import ProjectModel
 from .models.challenge import ChallengeModel
 from .models.task import TaskModel
+from .models.priority_rule import PriorityRuleModel
 from .api.project import Project
 from .api.challenge import Challenge
 from .api.task import Task

--- a/maproulette/__init__.py
+++ b/maproulette/__init__.py
@@ -7,7 +7,9 @@ from .api.configuration import Configuration
 from .models.project import ProjectModel
 from .models.challenge import ChallengeModel
 from .models.task import TaskModel
-from .models.priority_rule import *
+from .models.priority_rule import PriorityRule
+from .models.priority_rule import PriorityRuleModel
+from .models import priority_rule
 from .api.project import Project
 from .api.challenge import Challenge
 from .api.task import Task

--- a/maproulette/__init__.py
+++ b/maproulette/__init__.py
@@ -7,8 +7,7 @@ from .api.configuration import Configuration
 from .models.project import ProjectModel
 from .models.challenge import ChallengeModel
 from .models.task import TaskModel
-from .models.priority_rule import PriorityRule
-from .models.priority_rule import PriorityRuleModel
+from .models.priority_rule import PriorityRule, PriorityRuleModel
 from .models import priority_rule
 from .api.project import Project
 from .api.challenge import Challenge

--- a/maproulette/models/__init__.py
+++ b/maproulette/models/__init__.py
@@ -1,3 +1,4 @@
 from .project import ProjectModel
 from .challenge import ChallengeModel
 from .task import TaskModel
+from .priority_rule import PriorityRuleModel

--- a/maproulette/models/__init__.py
+++ b/maproulette/models/__init__.py
@@ -1,4 +1,4 @@
 from .project import ProjectModel
 from .challenge import ChallengeModel
 from .task import TaskModel
-from .priority_rule import *
+from .priority_rule import PriorityRule, PriorityRuleModel

--- a/maproulette/models/__init__.py
+++ b/maproulette/models/__init__.py
@@ -2,3 +2,4 @@ from .project import ProjectModel
 from .challenge import ChallengeModel
 from .task import TaskModel
 from .priority_rule import PriorityRuleModel
+from .priority_rule import PriorityRule

--- a/maproulette/models/__init__.py
+++ b/maproulette/models/__init__.py
@@ -1,5 +1,4 @@
 from .project import ProjectModel
 from .challenge import ChallengeModel
 from .task import TaskModel
-from .priority_rule import PriorityRuleModel
-from .priority_rule import PriorityRule
+from .priority_rule import *

--- a/maproulette/models/challenge.py
+++ b/maproulette/models/challenge.py
@@ -332,7 +332,6 @@ class ChallengeModel:
             "id": self._id,
             "name": self._name,
             "description": self._description,
-            "deleted": self.description,
             "parent": self._parent,
             "instruction": self._instruction,
             "difficulty": self._difficulty,

--- a/maproulette/models/priority_rule.py
+++ b/maproulette/models/priority_rule.py
@@ -1,0 +1,56 @@
+"""This module contains the definition of a priority rule object in MapRoulette."""
+
+import json
+import os
+
+VALID_TYPES = {'string', 'integer', 'double', 'long', 'nested rule'}
+
+
+class PriorityRuleModel:
+    """Definition for a MapRoulette priority rule"""
+
+    @property
+    def priority_value(self):
+        """The value for the priority rule"""
+        return self._priority_value
+
+    @priority_value.setter
+    def priority_value(self, value):
+        self._priority_value = value
+
+    @property
+    def priority_type(self):
+        """The type for the priority rule"""
+        return self._priority_type
+
+    @priority_type.setter
+    def priority_type(self, value):
+        if value not in VALID_TYPES:
+            raise ValueError("Priority type must be one of %s.", VALID_TYPES)
+        self._priority_type = value
+
+    @property
+    def priority_operator(self):
+        """The type for the priority rule"""
+        return self._priority_operator
+
+    @priority_operator.setter
+    def priority_operator(self, value):
+        self._priority_operator = value
+
+    def __init__(self, priority_value, priority_type, priority_operator):
+        self._priority_value = priority_value
+        self._priority_type = priority_type
+        self._priority_operator = priority_operator
+
+    def to_dict(self):
+        """Converts all non-null properties of a project object into a dictionary"""
+        return {
+            "value": self._priority_value,
+            "type": self._priority_type,
+            "operator": self._priority_operator
+        }
+
+    def to_json(self):
+        """Converts all non-null properties of a project object into a JSON object"""
+        return json.dumps(self.to_dict())

--- a/maproulette/models/priority_rule.py
+++ b/maproulette/models/priority_rule.py
@@ -3,7 +3,9 @@
 import json
 import os
 
-VALID_TYPES = {'string', 'integer', 'double', 'long', 'nested rule'}
+VALID_TYPES = {'string', 'integer', 'double', 'long'}
+VALID_STRING_OPERATORS = {'equal', 'not_equal', 'contains', 'not_contains', 'is_empty', 'is_not_empty'}
+VALID_NUMERIC_OPERATORS = {'==', '!=', '<', '<=', '>', '>='}
 
 
 class PriorityRuleModel:
@@ -26,7 +28,7 @@ class PriorityRuleModel:
     @priority_type.setter
     def priority_type(self, value):
         if value not in VALID_TYPES:
-            raise ValueError("Priority type must be one of %s.", VALID_TYPES)
+            raise ValueError(f"Priority type must be one of {VALID_TYPES}.")
         self._priority_type = value
 
     @property
@@ -36,9 +38,15 @@ class PriorityRuleModel:
 
     @priority_operator.setter
     def priority_operator(self, value):
+        if self.priority_type == 'string':
+            if value not in VALID_STRING_OPERATORS:
+                raise ValueError(f"Priority operator must be one of {VALID_STRING_OPERATORS}.")
+        else:
+            if value not in VALID_NUMERIC_OPERATORS:
+                raise ValueError(f"Priority operator must be one of {VALID_NUMERIC_OPERATORS}.")
         self._priority_operator = value
 
-    def __init__(self, priority_value, priority_type, priority_operator):
+    def __init__(self, priority_value=None, priority_type=None, priority_operator=None):
         self._priority_value = priority_value
         self._priority_type = priority_type
         self._priority_operator = priority_operator

--- a/maproulette/models/priority_rule.py
+++ b/maproulette/models/priority_rule.py
@@ -1,8 +1,8 @@
 """This module contains the definition of a priority rule object in MapRoulette."""
 
 import json
-import os
 
+VALID_CONDITIONS = {'OR', 'AND'}
 VALID_TYPES = {'string', 'integer', 'double', 'long'}
 VALID_STRING_OPERATORS = {'equal', 'not_equal', 'contains', 'not_contains', 'is_empty', 'is_not_empty'}
 VALID_NUMERIC_OPERATORS = {'==', '!=', '<', '<=', '>', '>='}
@@ -10,6 +10,53 @@ VALID_NUMERIC_OPERATORS = {'==', '!=', '<', '<=', '>', '>='}
 
 class PriorityRuleModel:
     """Definition for a MapRoulette priority rule"""
+
+    @property
+    def condition(self):
+        """The condition (AND/OR) to use to chain together multiple priority rules"""
+        return self._condition
+
+    @condition.setter
+    def condition(self, value):
+        if value not in VALID_CONDITIONS:
+            raise ValueError(f"Priority condition must be one of {VALID_CONDITIONS}.")
+        self._condition = value
+
+    @property
+    def rules(self):
+        """The list of priority rules to be used in the priority rule model"""
+        return self._rules
+
+    @rules.setter
+    def rules(self, value):
+        self._rules = value
+
+    def __init__(self, condition, rules):
+        self.condition = condition
+        self.rules = list()
+        if isinstance(rules, list):
+            for i in rules:
+                if isinstance(i, PriorityRule):
+                    self.rules.append(i.to_dict())
+                else:
+                    raise ValueError("Rules must be PriorityRule instances")
+        else:
+            raise ValueError("Rules must be a list of PriorityRule instances")
+
+    def to_dict(self):
+        """Converts all properties of a priority rule model object into a dictionary"""
+        return {
+            "condition": self._condition,
+            "rules": self._rules
+        }
+
+    def to_json(self):
+        """Converts all properties of a priority rule model object into a JSON object"""
+        return json.dumps(self.to_dict())
+
+
+class PriorityRule:
+    """Definition for a single priority rule"""
 
     @property
     def priority_value(self):
@@ -52,7 +99,7 @@ class PriorityRuleModel:
         self._priority_operator = priority_operator
 
     def to_dict(self):
-        """Converts all non-null properties of a project object into a dictionary"""
+        """Converts all properties of a priority rule object into a dictionary"""
         return {
             "value": self._priority_value,
             "type": self._priority_type,
@@ -60,5 +107,5 @@ class PriorityRuleModel:
         }
 
     def to_json(self):
-        """Converts all non-null properties of a project object into a JSON object"""
+        """Converts all properties of a priority rule object into a JSON object"""
         return json.dumps(self.to_dict())

--- a/maproulette/models/priority_rule.py
+++ b/maproulette/models/priority_rule.py
@@ -1,10 +1,13 @@
 """This module contains the definition of a priority rule object in MapRoulette."""
 
 import json
-import enum
+from enum import Enum, auto
 
 
-class ExtendedEnum(enum.Enum):
+class ExtendedEnum(Enum):
+    def _generate_next_value_(name, start, count, last_values):
+        return name.lower()
+
     @classmethod
     def list(cls):
         return [i.value for i in cls]
@@ -18,20 +21,20 @@ class Conditions(ExtendedEnum):
 
 class Types(ExtendedEnum):
     """An enumeration of valid types for a priority rule object"""
-    STRING = "string"
-    INTEGER = "integer"
-    DOUBLE = "double"
-    LONG = "long"
+    STRING = auto()
+    INTEGER = auto()
+    DOUBLE = auto()
+    LONG = auto()
 
 
 class StringOperators(ExtendedEnum):
     """An enumeration of valid string operators for a priority rule object"""
-    EQUAL = "equal"
-    NOT_EQUAL = "not_equal"
-    CONTAINS = "contains"
-    NOT_CONTAINS = "not_contains"
-    IS_EMPTY = "is_empty"
-    IS_NOT_EMPTY = "is_not_empty"
+    EQUAL = auto()
+    NOT_EQUAL = auto()
+    CONTAINS = auto()
+    NOT_CONTAINS = auto()
+    IS_EMPTY = auto()
+    IS_NOT_EMPTY = auto()
 
 
 class NumericOperators(ExtendedEnum):
@@ -94,7 +97,7 @@ class PriorityRuleModel:
         elif isinstance(rules, PriorityRule):
             self.rules.append(rules.to_dict())
         else:
-            raise ValueError("Rules must PriorityRule instances")
+            raise ValueError("Rules must be PriorityRule instances")
 
     def to_dict(self):
         """Converts all properties of a priority rule model object into a dictionary"""

--- a/maproulette/models/priority_rule.py
+++ b/maproulette/models/priority_rule.py
@@ -40,8 +40,10 @@ class PriorityRuleModel:
                     self.rules.append(i.to_dict())
                 else:
                     raise ValueError("Rules must be PriorityRule instances")
+        elif isinstance(rules, PriorityRule):
+            self.rules.append(rules.to_dict())
         else:
-            raise ValueError("Rules must be a list of PriorityRule instances")
+            raise ValueError("Rules must PriorityRule instances")
 
     def to_dict(self):
         """Converts all properties of a priority rule model object into a dictionary"""


### PR DESCRIPTION
### Description:
This PR adds an additional model for priority rules. This makes it easier to create priority rules for a challenge using the model as a template. It also makes a small fix the challenge model properties that I discovered while testing. The flow for creating a valid priority rule to pass to a challenge model is as follows: 

```python
# Create a configuration object
config = maproulette.Configuration()

# Create an API object
api = maproulette.Challenge(config)

# Create a challenge model
challenge_data = maproulette.ChallengeModel(name='Test_Challenge_Name')

# Create a rule by instantiating the PriorityRule object
rule_1 = maproulette.PriorityRule(priority_value='highway.footway', priority_type='string', priority_operator='equal')

# Pass this rule to a PriorityRuleModel object. The object can accept either a list of PriorityRule objects or a single instance
challenge_data.high_priority_rule = maproulette.PriorityRuleModel(condition='OR', rules=rule_1).to_json()

# Create challenge
api.create_challenge(challenge_data)
```

### Potential Impact:
This PR allows the user to easily create priority rules for a challenge by using the new model as a template. This should take some of the guesswork out of priority rule creation. 

### Unit Test Approach:
I tested this new functionality by creating a new challenge. That challenge can be found [here](https://maproulette.org/browse/challenges/13637). The high priority rule was updated as expected using the rule shown in the example above. 

### Test Results:
Tox tests passed. Test challenge looks as expected. 
