### PR TITLE
Add travis & pypi badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # MapRoulette - A Python Client for the MapRoulette API
 
-https://maproulette-python-client.readthedocs.io/
+
+https://maproulette-python-client.readthedocs.io
+
+[![PyPI version](https://badge.fury.io/py/maproulette.svg)](https://badge.fury.io/py/maproulette)
+[![Build Status](https://travis-ci.com/osmlab/maproulette-python-client.svg?branch=master)](https://travis-ci.com/osmlab/maproulette-python-client)
 
 This client makes it easy for users to communicate with the MapRoulette API from within
 their Python environment. In the example below, we are able to access a MapRoulette project in just four lines of code:


### PR DESCRIPTION
### Description:

Adds pypi and travis-ci badges to readme. Travis badge is tied to `master` branch. Opening to switching this to dev if it makes more sense

### Potential Impact:

N/A

### Unit Test Approach:

N/A

### Test Results:

N/A
