### PR TITLE
Improve exceptions and fix JSON decoding bug

### DIFF
--- a/maproulette/api/errors.py
+++ b/maproulette/api/errors.py
@@ -19,29 +19,49 @@ class MapRouletteBaseException(Exception):
 
 class NotFoundError(MapRouletteBaseException):
     """Resource cannot be found"""
-    def __init__(self, message='Resource not found.', status=None, payload=None):
-        super().__init__(message=message, status=status, payload=payload)
+    def __init__(self, message=None, status=None, payload=None):
+        if message:
+            self.message = message
+        else:
+            self.message = "Resource cannot be found."
+        super().__init__(message=self.message, status=status, payload=payload)
 
 
 class ConnectionUnavailableError(MapRouletteBaseException):
     """A connection error occurred"""
-    def __init__(self, message='A connection error occurred.', status=None, payload=None):
-        super().__init__(message=message, status=status, payload=payload)
+    def __init__(self, message=None, status=None, payload=None):
+        if message:
+            self.message = message
+        else:
+            self.message = "A connection error occurred."
+        super().__init__(message=self.message, status=status, payload=payload)
 
 
 class UnauthorizedError(MapRouletteBaseException):
     """The user is not authorized to make this request"""
-    def __init__(self, message='The user is not authorized to make this request.', status=None, payload=None):
-        super().__init__(message=message, status=status, payload=payload)
+    def __init__(self, message=None, status=None, payload=None):
+        if message:
+            self.message = message
+        else:
+            self.message = "The user is not authorized to make this request."
+        super().__init__(message=self.message, status=status, payload=payload)
 
 
 class HttpError(MapRouletteBaseException):
     """An HTTP error occurred"""
-    def __init__(self, message='An HTTP error occurred.', status=None, payload=None):
-        super().__init__(message=message, status=status, payload=payload)
+    def __init__(self, message=None, status=None, payload=None):
+        if message:
+            self.message = message
+        else:
+            self.message = "An HTTP error occurred."
+        super().__init__(message=self.message, status=status, payload=payload)
 
 
 class InvalidJsonError(MapRouletteBaseException):
     """Errors produced from an invalid JSON object"""
-    def __init__(self, message='Invalid JSON payload.', status=None, payload=None):
-        super().__init__(message=message, status=status, payload=payload)
+    def __init__(self, message=None, status=None, payload=None):
+        if message:
+            self.message = message
+        else:
+            self.message = "Invalid JSON payload."
+        super().__init__(message=self.message, status=status, payload=payload)

--- a/maproulette/api/errors.py
+++ b/maproulette/api/errors.py
@@ -3,34 +3,45 @@
 
 class MapRouletteBaseException(Exception):
     """MapRoulette Base Exception"""
-    def __init__(self, message, status=None, payload=None):
+    def __init__(self, message, status, payload):
         self.message = message
         self.status = status
         self.payload = payload
 
     def __str__(self):
-        return repr({
+        e = {
                 "status": self.status,
                 "message": self.message,
                 "payload": self.payload
-                })
+            }
+        return repr({k: v for (k, v) in e.items() if v is not None})
 
 
 class NotFoundError(MapRouletteBaseException):
     """Resource cannot be found"""
+    def __init__(self, message='Resource not found.', status=None, payload=None):
+        super().__init__(message=message, status=status, payload=payload)
 
 
 class ConnectionUnavailableError(MapRouletteBaseException):
     """A connection error occurred"""
+    def __init__(self, message='A connection error occurred.', status=None, payload=None):
+        super().__init__(message=message, status=status, payload=payload)
 
 
 class UnauthorizedError(MapRouletteBaseException):
     """The user is not authorized to make this request"""
+    def __init__(self, message='The user is not authorized to make this request.', status=None, payload=None):
+        super().__init__(message=message, status=status, payload=payload)
 
 
 class HttpError(MapRouletteBaseException):
     """An HTTP error occurred"""
+    def __init__(self, message='An HTTP error occurred.', status=None, payload=None):
+        super().__init__(message=message, status=status, payload=payload)
 
 
 class InvalidJsonError(MapRouletteBaseException):
     """Errors produced from an invalid JSON object"""
+    def __init__(self, message='Invalid JSON payload.', status=None, payload=None):
+        super().__init__(message=message, status=status, payload=payload)

--- a/maproulette/api/errors.py
+++ b/maproulette/api/errors.py
@@ -9,12 +9,12 @@ class MapRouletteBaseException(Exception):
         self.payload = payload
 
     def __str__(self):
-        e = {
+        error = {
                 "status": self.status,
                 "message": self.message,
                 "payload": self.payload
             }
-        return repr({k: v for (k, v) in e.items() if v is not None})
+        return repr({k: v for (k, v) in error.items() if v is not None})
 
 
 class NotFoundError(MapRouletteBaseException):

--- a/maproulette/api/maproulette_server.py
+++ b/maproulette/api/maproulette_server.py
@@ -64,17 +64,17 @@ class MapRouletteServer:
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
                 raise NotFoundError(
-                    message=json.loads(e.response.text)['message'],
+                    message=self.parse_response_message(e.response),
                     status=e.response.status_code
                 ) from None
             else:
                 raise HttpError(
-                    message=json.loads(e.response.text)['message'],
+                    message=self.parse_response_message(e.response),
                     status=e.response.status_code
                 ) from None
         except (requests.ConnectionError, requests.Timeout) as e:
             raise ConnectionUnavailableError(
-                message=json.loads(e.response.text)['message'],
+                message=self.parse_response_message(e.response),
                 status=e.response.status_code
             ) from None
         try:
@@ -105,17 +105,17 @@ class MapRouletteServer:
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 400:
                 raise InvalidJsonError(
-                    message=json.loads(e.response.text)['message'],
+                    message=self.parse_response_message(e.response),
                     status=e.response.status_code
                 ) from None
             elif e.response.status_code == 401:
                 raise UnauthorizedError(
-                    message=json.loads(e.response.text)['message'],
+                    message=self.parse_response_message(e.response),
                     status=e.response.status_code
                 ) from None
             else:
                 raise HttpError(
-                    message=json.loads(e.response.text)['message'],
+                    message=self.parse_response_message(e.response),
                     status=e.response.status_code
                 ) from None
         except (requests.ConnectionError, requests.Timeout) as e:
@@ -148,17 +148,17 @@ class MapRouletteServer:
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 400:
                 raise InvalidJsonError(
-                    message=json.loads(e.response.text)['message'],
+                    message=self.parse_response_message(e.response),
                     status=e.response.status_code
                 ) from None
             elif e.response.status_code == 401:
                 raise UnauthorizedError(
-                    message=json.loads(e.response.text)['message'],
+                    message=self.parse_response_message(e.response),
                     status=e.response.status_code
                 ) from None
             else:
                 raise HttpError(
-                    message=json.loads(e.response.text)['message'],
+                    message=self.parse_response_message(e.response),
                     status=e.response.status_code
                 ) from None
         except (requests.ConnectionError, requests.Timeout) as e:
@@ -189,17 +189,17 @@ class MapRouletteServer:
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 401:
                 raise UnauthorizedError(
-                    message=json.loads(e.response.text)['message'],
+                    message=self.parse_response_message(e.response),
                     status=e.response.status_code
                 ) from None
             elif e.response.status_code == 404:
                 raise NotFoundError(
-                    message=json.loads(e.response.text)['message'],
+                    message=self.parse_response_message(e.response),
                     status=e.response.status_code
                 ) from None
             else:
                 raise HttpError(
-                    message=json.loads(e.response.text)['message'],
+                    message=self.parse_response_message(e.response),
                     status=e.response.status_code
                 ) from None
         except (requests.ConnectionError, requests.Timeout) as e:
@@ -227,3 +227,15 @@ class MapRouletteServer:
             return True
         except ValueError:
             return False
+
+    @staticmethod
+    def parse_response_message(response):
+        """Method to determine the message body from a response object. Will return None if message cannot be parsed.
+
+        :param response: the Requests response object
+        :returns: the response message if parsable, otherwise None
+        """
+        try:
+            return json.loads(response.text)['message']
+        except ValueError:
+            return None

--- a/maproulette/api/maproulette_server.py
+++ b/maproulette/api/maproulette_server.py
@@ -64,28 +64,25 @@ class MapRouletteServer:
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 404:
                 raise NotFoundError(
-                    message='Resource not found',
-                    status=e.response.status_code,
-                    payload=e.response
+                    message=json.loads(e.response.text)['message'],
+                    status=e.response.status_code
                 ) from None
             else:
                 raise HttpError(
-                    message='An HTTP error occurred',
-                    status=e.response.status_code,
-                    payload=e.response
+                    message=json.loads(e.response.text)['message'],
+                    status=e.response.status_code
                 ) from None
         except (requests.ConnectionError, requests.Timeout) as e:
             raise ConnectionUnavailableError(
-                message="Connection Unavailable",
-                status=e.response.status_code,
-                payload=response
+                message=json.loads(e.response.text)['message'],
+                status=e.response.status_code
             ) from None
         try:
             return {
                 "data": response.json(),
                 "status": response.status_code
             }
-        except json.decoder.JSONDecodeError:
+        except ValueError:
             return {
                 "status": response.status_code
             }
@@ -108,21 +105,18 @@ class MapRouletteServer:
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 400:
                 raise InvalidJsonError(
-                    message='Invalid JSON payload',
-                    status=e.response.status_code,
-                    payload=e.response
+                    message=json.loads(e.response.text)['message'],
+                    status=e.response.status_code
                 ) from None
             elif e.response.status_code == 401:
                 raise UnauthorizedError(
-                    message='The user is not authorized to make this request',
-                    status=e.response.status_code,
-                    payload=e.response
+                    message=json.loads(e.response.text)['message'],
+                    status=e.response.status_code
                 ) from None
             else:
                 raise HttpError(
-                    message='An HTTP error occurred',
-                    status=e.response.status_code,
-                    payload=e.response
+                    message=json.loads(e.response.text)['message'],
+                    status=e.response.status_code
                 ) from None
         except (requests.ConnectionError, requests.Timeout) as e:
             raise ConnectionUnavailableError(e) from None
@@ -131,7 +125,7 @@ class MapRouletteServer:
                 "data": response.json(),
                 "status": response.status_code
             }
-        except json.decoder.JSONDecodeError:
+        except ValueError:
             return {
                 "status": response.status_code
             }
@@ -154,21 +148,18 @@ class MapRouletteServer:
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 400:
                 raise InvalidJsonError(
-                    message='Invalid JSON payload',
-                    status=e.response.status_code,
-                    payload=e.response
+                    message=json.loads(e.response.text)['message'],
+                    status=e.response.status_code
                 ) from None
             elif e.response.status_code == 401:
                 raise UnauthorizedError(
-                    message='The user is not authorized to make this request',
-                    status=e.response.status_code,
-                    payload=e.response
+                    message=json.loads(e.response.text)['message'],
+                    status=e.response.status_code
                 ) from None
             else:
                 raise HttpError(
-                    message='An HTTP error occurred',
-                    status=e.response.status_code,
-                    payload=e.response
+                    message=json.loads(e.response.text)['message'],
+                    status=e.response.status_code
                 ) from None
         except (requests.ConnectionError, requests.Timeout) as e:
             raise ConnectionUnavailableError(e) from None
@@ -177,7 +168,7 @@ class MapRouletteServer:
                 "data": response.json(),
                 "status": response.status_code
             }
-        except json.decoder.JSONDecodeError:
+        except ValueError:
             return {
                 "status": response.status_code
             }
@@ -198,21 +189,18 @@ class MapRouletteServer:
         except requests.exceptions.HTTPError as e:
             if e.response.status_code == 401:
                 raise UnauthorizedError(
-                    message='The user is not authorized to make this request',
-                    status=e.response.status_code,
-                    payload=e.response
+                    message=json.loads(e.response.text)['message'],
+                    status=e.response.status_code
                 ) from None
             elif e.response.status_code == 404:
                 raise NotFoundError(
-                    message='Resource not found',
-                    status=e.response.status_code,
-                    payload=e.response
+                    message=json.loads(e.response.text)['message'],
+                    status=e.response.status_code
                 ) from None
             else:
                 raise HttpError(
-                    message='An HTTP error occurred',
-                    status=e.response.status_code,
-                    payload=e.response
+                    message=json.loads(e.response.text)['message'],
+                    status=e.response.status_code
                 ) from None
         except (requests.ConnectionError, requests.Timeout) as e:
             raise ConnectionUnavailableError(e) from None
@@ -221,7 +209,7 @@ class MapRouletteServer:
                 "data": response.json(),
                 "status": response.status_code
             }
-        except json.decoder.JSONDecodeError:
+        except ValueError:
             return {
                 "status": response.status_code
             }

--- a/maproulette/api/maproulette_server.py
+++ b/maproulette/api/maproulette_server.py
@@ -237,5 +237,5 @@ class MapRouletteServer:
         """
         try:
             return json.loads(response.text)['message']
-        except ValueError:
+        except (ValueError, KeyError):
             return None

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -26,7 +26,6 @@ class TestAPI(unittest.TestCase):
             server_instance.get(endpoint='')
         assert context.exception.message == 'Resource not found'
         assert context.exception.status == 404
-        assert context.exception.payload == 'error payload'
 
     @patch('maproulette.api.maproulette_server.MapRouletteServer.get')
     @patch('requests.Session.get')
@@ -265,3 +264,20 @@ class TestAPI(unittest.TestCase):
         assert context.exception.message == 'Connection Unavailable'
         assert context.exception.status == 500
         assert context.exception.payload == 'error payload'
+
+    @patch('json.loads')
+    def test_parse_response_message(self, mock_loads, server_instance=server):
+        mock_loads.return_value = {
+            'message': 'some message'
+        }
+        self.assertTrue(server_instance.parse_response_message(mock_loads))
+
+    @patch('json.loads')
+    def test_parse_response_message_value_error(self, mock_loads, server_instance=server):
+        mock_loads.side_effect = ValueError()
+        self.assertIsNone(server_instance.parse_response_message(mock_loads))
+
+    @patch('json.loads')
+    def test_parse_response_message_key_error(self, mock_loads, server_instance=server):
+        mock_loads.side_effect = KeyError()
+        self.assertIsNone(server_instance.parse_response_message(mock_loads))


### PR DESCRIPTION
### Description:
This PR addresses two issues: 
* https://github.com/osmlab/maproulette-python-client/issues/56 [Feature Request] Provide message from API response in exception when relevant
* https://github.com/osmlab/maproulette-python-client/issues/55 [BUG] json.decoder.JSONDecodeError not caught due to Requests using simplejson.errors.JSONDecodeError

The first issue is addressed by changing the information that is being passed to the error classes. Originally, we had sent the `error.response` object as the payload and hard-coded the message that was used. Instead, I try to read the message from the response using `json.loads(e.response.text)['message']`. If the response message cannot be parsed, a default message for each exception type will be returned. I also eliminate the setting of the payload parameter as we are not storing any useful information in that parameter as of now. Finally, when the final exception is printed, I filter all parameters that have a value of `None`.

The second issue is addressed by catching the JSON exception with a generic `ValueError` rather than `json.decoder.JSONDecodeError`. This allows us to properly catch that exception and avoid parsing the empty response body object.

### Potential Impact:
This PR changes the exception handling for this package. 

### Unit Test Approach:
Tox

### Test Results:
Tox passing.
