### PR TITLE
Adding batch functionality for posting new tasks

### DIFF
--- a/examples/challenge_examples.py
+++ b/examples/challenge_examples.py
@@ -58,4 +58,5 @@ with open('data/Example_Geometry.geojson', 'r') as data_file:
     data = json.loads(data_file.read())
 
 # Printing response:
-print(api.add_tasks_to_challenge(data, challenge_id))
+response = api.add_tasks_to_challenge(data, challenge_id)
+

--- a/examples/challenge_examples.py
+++ b/examples/challenge_examples.py
@@ -58,5 +58,4 @@ with open('data/Example_Geometry.geojson', 'r') as data_file:
     data = json.loads(data_file.read())
 
 # Printing response:
-response = api.add_tasks_to_challenge(data, challenge_id)
-
+print(json.dumps(api.add_tasks_to_challenge(data, challenge_id)))

--- a/maproulette/api/challenge.py
+++ b/maproulette/api/challenge.py
@@ -1,6 +1,5 @@
 """This module contains the methods that the user will use directly to interact with MapRoulette challenges"""
 
-import geojson
 from maproulette.api.maproulette_server import MapRouletteServer
 from maproulette.models.challenge import ChallengeModel
 
@@ -260,42 +259,6 @@ class Challenge(MapRouletteServer):
             body=data)
         return response
 
-    def add_tasks_to_challenge_batch(self, data, challenge_id, batch_size=100):
-        """Method to add tasks to an existing challenge
-
-        :param data: a GeoJSON containing geometry of tasks to be added to a challenge
-        :param challenge_id: the ID corresponding to the challenge that tasks will be added to
-        :param batch_size: the number of features within the GeoJSON to send to the API at a time. Default is 100.
-        :returns: the API response from the PUT request
-        """
-        if isinstance(data, str):
-            try:
-                geojson.loads(data)
-            except ValueError
-        features = data['features']
-        feature_collection = {'type': 'FeatureCollection'}
-        remaining_features = len(features)
-        bundle = []
-        count = 0
-        for index, feature in enumerate(features):
-            bundle.append(feature)
-            count += 1
-            if count == batch_size:
-                feature_collection['features'] = bundle
-                self.add_tasks_to_challenge(
-                    challenge_id=challenge_id,
-                    data=feature_collection
-                )
-                remaining_features -= count
-                bundle = []
-                count = 0
-        if remaining_features > 0:
-            feature_collection['features'] = bundle
-            self.add_tasks_to_challenge(
-                challenge_id=challenge_id,
-                data=feature_collection
-            )
-
     def delete_challenge(self, challenge_id, immediate="false"):
         """Method to delete a challenge by using the corresponding challenge ID
 
@@ -351,11 +314,3 @@ class Challenge(MapRouletteServer):
         :returns: True if instance of model
         """
         return bool(isinstance(input_object, ChallengeModel))
-
-    @staticmethod
-    def string_to_geojson(input_object):
-        """Converts string to GeoJSON object using the geojson package
-
-        :param input_object: string representing the GeoJSON object
-        :return: a valid
-        """

--- a/maproulette/api/maproulette_server.py
+++ b/maproulette/api/maproulette_server.py
@@ -43,6 +43,7 @@ class MapRouletteServer:
                     return True
             except requests.exceptions.ConnectionError:
                 print(f"Connection not available. Attempt {str(i+1)} out of {str(retries)}")
+                time.sleep(delay)
 
         raise ConnectionUnavailableError(
             message='Specified server unavailable'

--- a/maproulette/api/task.py
+++ b/maproulette/api/task.py
@@ -30,15 +30,20 @@ class Task(MapRouletteServer):
             endpoint=f"/task/{task_id}/history")
         return response
 
-    def create_tasks(self, data):
-        """Method to create a batch of tasks
+    def create_tasks(self, data, batch_size=100):
+        """Method to create a batch of tasks using the specified batch_size.
 
         :param data: a JSON input containing task details
+        :param batch_size: the number of tasks to post per API call. The default is 100.
+        :type batch_size: int
         :returns: the API response from the POST request
         """
-        response = self.post(
-            endpoint="/tasks",
-            body=data)
+        response = []
+        for batch in self.batch_generator(input_list=data, chunk_size=batch_size):
+            response.append(self.post(
+                endpoint="/tasks",
+                body=batch)
+            )
         return response
 
     def update_tasks(self, data):
@@ -157,3 +162,15 @@ class Task(MapRouletteServer):
         :returns: True if instance of model
         """
         return bool(isinstance(input_object, TaskModel))
+
+    @staticmethod
+    def batch_generator(input_list, chunk_size):
+        """Method to yield successive n-sized chunks from input_list
+
+        :param input_list: the list to break into chunks
+        :param chunk_size: the number of list items to include per chunk
+        :type chunk_size: int
+        :returns: an iterator for the n-sized chunks of the input_list
+        """
+        for i in range(0, len(input_list), chunk_size):
+            yield input_list[i:i + chunk_size]

--- a/maproulette/api/task.py
+++ b/maproulette/api/task.py
@@ -30,11 +30,11 @@ class Task(MapRouletteServer):
             endpoint=f"/task/{task_id}/history")
         return response
 
-    def create_tasks(self, data, batch_size=100):
+    def create_tasks(self, data, batch_size=5000):
         """Method to create a batch of tasks using the specified batch_size.
 
         :param data: a JSON input containing task details
-        :param batch_size: the number of tasks to post per API call. The default is 100.
+        :param batch_size: the number of tasks to post per API call. The default is 5000.
         :type batch_size: int
         :returns: the API response from the POST request
         """

--- a/maproulette/models/task.py
+++ b/maproulette/models/task.py
@@ -190,6 +190,7 @@ class TaskModel:
             "id": self._id,
             "name": self._name,
             "parent": self._parent,
+            "geometries": self._geometries,
             "instruction": self._instruction,
             "location": self._location,
             "suggestedFix": self._suggested_fix,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests==2.23.0
 tox==3.14.5
 sphinx==2.4.4
 sphinx_rtd_theme
+geojson

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ requests==2.23.0
 tox==3.14.5
 sphinx==2.4.4
 sphinx_rtd_theme
-geojson

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -26,13 +26,16 @@ class TestTaskAPI(unittest.TestCase):
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_create_tasks(self, mock_request, api_instance=api):
+        test_tasks = []
         geometries = test_geojson['features'][0]['geometry']
         test_task_model = maproulette.TaskModel(name='test_task',
                                                 parent='12345',
                                                 geometries=geometries)
+        test_tasks.append(test_task_model.to_dict())
         mock_request.return_value.status_code = '200'
-        response = api_instance.create_tasks(test_task_model)
-        self.assertEqual(response['status'], '200')
+        responses = api_instance.create_tasks(test_tasks)
+        for response in responses:
+            self.assertEqual(response['status'], '200')
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_update_tasks(self, mock_request, api_instance=api):

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -91,3 +91,15 @@ class TestTaskAPI(unittest.TestCase):
         mock_request.return_value.status_code = '200'
         response = api_instance.get_task_comments(task_id)
         self.assertEqual(response['status'], '200')
+
+    def test_batch_generator(self, api_instance=api):
+
+        batch_size = 10
+        test_length = 1234
+        test_list = [i for i in range(test_length)]
+        running_total = 0
+        for chunk in api_instance.batch_generator(test_list, batch_size):
+            running_total += len(chunk)
+            self.assertIsInstance(chunk, list)
+            self.assertLessEqual(len(chunk), batch_size)
+        self.assertEqual(test_length, running_total)


### PR DESCRIPTION
### Description:
This PR adds batch functionality to the `POST /tasks` endpoint via the `create_tasks` method. It also fixes a bug in the task model object and enhances the `__check_health` method. Example of how to use this new functionality by creating tasks using an existing GeoJSON:
``` python
import maproulette
import json

# Create config object
config = maproulette.Configuration(
    api_key='{MY_API_KEY}'
)

# Create API objects
task_api = maproulette.Task(config)
challenge_api = maproulette.Challenge(config)

# Creating a new challenge
challenge_data = maproulette.ChallengeModel(name='Test_Challenge_Name_20200817')
challenge_data.instruction = 'Do something'
response = challenge_api.create_challenge(challenge_data)
challenge_id = response['data']['id']

# Load GeoJSON file
with open('/path/to/geojson/file.geojson', 'r') as data_file:
    data = json.load(data_file)

# Using a dictionary to create each task from scratch
tasks = []
for f in data['features']:
    task = dict()
    task['name'] = str(f['properties']['osmid'])
    task['parent'] = challenge_id
    task['geometries'] = {"type": "FeatureCollection", "features": [f]}
    tasks.append(task)

# Or using the TaskModel object instead
tasks = []
for f in data['features']:
    task = maproulette.TaskModel(
        name=str(f['properties']['osmid']),
        parent=challenge_id,
        geometries={"type": "FeatureCollection", "features": [f]}
    ).to_dict()
    tasks.append(task)

# Post tasks using a batch size of 10 tasks per API call
print(task_api.create_tasks(data=tasks, batch_size=10))
```

### Potential Impact:
This PR fixes an issue with the task model where geometries would not be set.

### Unit Test Approach:
Tox

### Test Results:
Tox passing.
