### PR TITLE
Adding endpoint for challenge keywords/tags

### DIFF
--- a/examples/challenge_examples.py
+++ b/examples/challenge_examples.py
@@ -19,6 +19,10 @@ project_id = '2491'
 print(json.dumps(api.get_challenge_by_name(project_id=project_id,
                                            challenge_name=challenge_name), indent=4, sort_keys=True))
 
+# We can also use challenges' set tags to retrieve them:
+challenge_tags = 'River'
+print(json.dumps(api.get_challenges_by_tags(challenge_tags=challenge_tags), indent=4, sort_keys=True))
+
 # We can access challenge statistics as well:
 print(json.dumps(api.get_challenge_statistics_by_id(challenge_id)))
 

--- a/maproulette/api/challenge.py
+++ b/maproulette/api/challenge.py
@@ -54,6 +54,25 @@ class Challenge(MapRouletteServer):
         response = self.get(endpoint=f"/project/{project_id}/challenge/{challenge_name}")
         return response
 
+    def get_challenges_by_tags(self, challenge_tags, limit=10, page=0):
+        """Method to retrieve challenge information via tags applied to the challenge
+
+        :param challenge_tags: a comma-separated list of tags to search challenges for
+        :param limit: the limit to the number of results returned in the response. Default is 10
+        :param page: used in conjunction with the limit parameter to page through X number of responses. Default is 0.
+        :returns: the API responsse from the GET request
+        """
+        query_params = {
+            "tags": str(challenge_tags),
+            "limit ": str(limit),
+            "page": str(page)
+        }
+        response = self.get(
+            endpoint=f"/challenges/tags",
+            params=query_params
+        )
+        return response
+
     def get_virtual_challenge_by_id(self, challenge_id):
         """Method to retrieve an existing virtual challenge
 

--- a/maproulette/api/challenge.py
+++ b/maproulette/api/challenge.py
@@ -60,7 +60,7 @@ class Challenge(MapRouletteServer):
         :param challenge_tags: a comma-separated list of tags to search challenges for
         :param limit: the limit to the number of results returned in the response. Default is 10
         :param page: used in conjunction with the limit parameter to page through X number of responses. Default is 0.
-        :returns: the API responsse from the GET request
+        :returns: the API response from the GET request
         """
         query_params = {
             "tags": str(challenge_tags),

--- a/tests/test_challenge_api.py
+++ b/tests/test_challenge_api.py
@@ -67,6 +67,13 @@ class TestChallengeAPI(unittest.TestCase):
         self.assertEqual(response['status'], '200')
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
+    def test_get_challenges_by_tags(self, mock_request, api_instance=api):
+        test_challenge_tag = 'River'
+        mock_request.return_value.status_code = '200'
+        response = api_instance.get_challenges_by_tags(test_challenge_tag)
+        self.assertEqual(response['status'], '200')
+
+    @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_virtual_challenge_by_id(self, mock_request, api_instance=api):
         test_virtual_challenge_id = '12345'
         mock_request.return_value.status_code = '200'


### PR DESCRIPTION
### Description:
Adds functionality to interact with the /challenges/tags endpoint

Resolves #54 

### Potential Impact:
Challenges will now be queryable via their keywords/tags

### Unit Test Approach:
Integrated into the existing unit test framework

### Test Results:
Example added to existing examples section

Test results return an existing challenge with the provided keyword/tag
