### PR TITLE
Refactoring existing endpoint unit tests

### DIFF
--- a/tests/sample_data.py
+++ b/tests/sample_data.py
@@ -30,3 +30,8 @@ create_challenge_output = json.dumps(
     'description': 'This is a test challenge',
     'instruction': 'Do something',
     'overpassQL': test_overpassQL_query})
+
+test_project = json.loads('''{"name": "Test_Project_Name",
+                           "description": "This is a test project"
+                           }'''
+                          )

--- a/tests/sample_data.py
+++ b/tests/sample_data.py
@@ -33,5 +33,4 @@ create_challenge_output = json.dumps(
 
 test_project = json.loads('''{"name": "Test_Project_Name",
                            "description": "This is a test project"
-                           }'''
-                          )
+                           }''')

--- a/tests/sample_data.py
+++ b/tests/sample_data.py
@@ -23,6 +23,10 @@ test_geojson = json.loads('''{
     ]
 }''')
 
-test_overpassQL_query = '''way["name"="Københavns Lufthavn"];
-out body geom qt;'''
+test_overpassQL_query = '''way["name"="Københavns Lufthavn"];\nout body geom qt;'''
 
+create_challenge_output = json.dumps(
+    {'name': 'Test_Challenge_Name',
+    'description': 'This is a test challenge',
+    'instruction': 'Do something',
+    'overpassQL': test_overpassQL_query})

--- a/tests/test_challenge_api.py
+++ b/tests/test_challenge_api.py
@@ -8,27 +8,32 @@ class TestChallengeAPI(unittest.TestCase):
 
     config = maproulette.Configuration(api_key="API_KEY")
     api = maproulette.Challenge(config)
+    url = config.api_url
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_by_id(self, mock_request, api_instance=api):
         test_challenge_id = '12974'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_challenge_by_id(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_challenge_by_id(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/challenge/12974',
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_statistics_by_id(self, mock_request, api_instance=api):
         test_challenge_id = '12974'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_challenge_statistics_by_id(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_challenge_statistics_by_id(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/data/challenge/{test_challenge_id}',
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_tasks(self, mock_request, api_instance=api):
         test_challenge_id = '12974'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_challenge_tasks(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_challenge_tasks(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/challenge/{test_challenge_id}/tasks',
+            params={'limit': '10',
+                    'page': '0'})
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_create_challenge(self, mock_request, api_instance=api):
@@ -36,16 +41,21 @@ class TestChallengeAPI(unittest.TestCase):
                                                           instruction='Do something',
                                                           description='This is a test challenge',
                                                           overpassQL=test_overpassQL_query)
-        mock_request.return_value.status_code = '200'
-        response = api_instance.create_challenge(test_challenge_model)
-        self.assertEqual(response['status'], '200')
+        api_instance.create_challenge(test_challenge_model)
+        mock_request.assert_called_once_with(
+            f'{self.url}/challenge',
+            json={'name': 'Test_Challenge_Name', 'description': 'This is a test challenge',
+                  'instruction': 'Do something',
+                  'overpassQL': 'way["name"="Københavns Lufthavn"];\nout body geom qt;'},
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_add_tasks_to_challenge(self, mock_request, api_instance=api):
         test_challenge_id = '12978'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.add_tasks_to_challenge(test_geojson, test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.add_tasks_to_challenge(test_geojson, test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_create_virtual_challenge(self, mock_request, api_instance=api):
@@ -54,94 +64,107 @@ class TestChallengeAPI(unittest.TestCase):
                                                           instruction='Do something',
                                                           description='This is a test challenge',
                                                           overpassQL=test_overpassQL_query)
-        mock_request.return_value.status_code = '200'
-        response = api_instance.create_virtual_challenge(test_challenge_model)
-        self.assertEqual(response['status'], '200')
+        api_instance.create_virtual_challenge(test_challenge_model)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_by_name(self, mock_request, api_instance=api):
         test_project_id = '12345'
         test_challenge_name = 'Test_Challenge_Name'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_challenge_by_name(test_project_id, test_challenge_name)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_challenge_by_name(test_project_id, test_challenge_name)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_virtual_challenge_by_id(self, mock_request, api_instance=api):
         test_virtual_challenge_id = '12345'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_virtual_challenge_by_id(test_virtual_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_virtual_challenge_by_id(test_virtual_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_listing(self, mock_request, api_instance=api):
         test_project_ids = '12345,67891,23456'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_challenge_listing(test_project_ids)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_challenge_listing(test_project_ids)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_children(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_challenge_children(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_challenge_children(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_comments(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_challenge_comments(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_challenge_comments(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_extract_challenge_comments(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.extract_challenge_comments(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.extract_challenge_comments(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_extract_task_summaries(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.extract_task_summaries(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.extract_task_summaries(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_geojson(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_challenge_geojson(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_challenge_geojson(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_update_task_priorities(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.update_task_priorities(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.update_task_priorities(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_reset_task_instructions(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.reset_task_instructions(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.reset_task_instructions(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.delete')
     def test_delete_challenge(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.delete_challenge(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.delete_challenge(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.delete')
     def test_delete_challenge_tasks(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.delete_challenge_tasks(test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.delete_challenge_tasks(test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_update_challenge(self, mock_request, api_instance=api):
@@ -150,6 +173,7 @@ class TestChallengeAPI(unittest.TestCase):
                                                           instruction='Do something',
                                                           description='This is a test challenge',
                                                           overpassQL=test_overpassQL_query)
-        mock_request.return_value.status_code = '200'
-        response = api_instance.update_challenge(test_challenge_id, test_challenge_model)
-        self.assertEqual(response['status'], '200')
+        api_instance.update_challenge(test_challenge_id, test_challenge_model)
+        mock_request.assert_called_once_with(
+            f'{self.url}'
+        )

--- a/tests/test_challenge_api.py
+++ b/tests/test_challenge_api.py
@@ -137,11 +137,11 @@ class TestChallengeAPI(unittest.TestCase):
             f'{self.url}/challenge/{test_challenge_id}/tasks/extract',
             params={'limit': '10',
                     'page': '0',
-                    'status': "",
-                    'reviewStatus': "",
-                    'priority': "",
-                    'exportProperties': "",
-                    'taskPropertySearch': ""}
+                    'status': '',
+                    'reviewStatus': '',
+                    'priority': '',
+                    'exportProperties': '',
+                    'taskPropertySearch': ''}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
@@ -150,10 +150,10 @@ class TestChallengeAPI(unittest.TestCase):
         api_instance.get_challenge_geojson(test_challenge_id)
         mock_request.assert_called_once_with(
             f'{self.url}/challenge/view/{test_challenge_id}',
-            params={'status': "",
-                    'reviewStatus': "",
-                    'priority': "",
-                    'taskPropertySearch': ""}
+            params={'status': '',
+                    'reviewStatus': '',
+                    'priority': '',
+                    'taskPropertySearch': ''}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
@@ -191,7 +191,7 @@ class TestChallengeAPI(unittest.TestCase):
         api_instance.delete_challenge_tasks(test_challenge_id)
         mock_request.assert_called_once_with(
             f'{self.url}/challenge/{test_challenge_id}/tasks',
-            params={'statusFilters': ""}
+            params={'statusFilters': ''}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')

--- a/tests/test_challenge_api.py
+++ b/tests/test_challenge_api.py
@@ -1,7 +1,8 @@
 import maproulette
 import unittest
-from tests.sample_data import test_geojson, test_overpassQL_query
+from tests.sample_data import test_geojson, test_overpassQL_query, create_challenge_output
 from unittest.mock import patch
+import json
 
 
 class TestChallengeAPI(unittest.TestCase):
@@ -44,9 +45,7 @@ class TestChallengeAPI(unittest.TestCase):
         api_instance.create_challenge(test_challenge_model)
         mock_request.assert_called_once_with(
             f'{self.url}/challenge',
-            json={'name': 'Test_Challenge_Name', 'description': 'This is a test challenge',
-                  'instruction': 'Do something',
-                  'overpassQL': 'way["name"="Københavns Lufthavn"];\nout body geom qt;'},
+            json=json.loads(create_challenge_output),
             params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
@@ -54,8 +53,9 @@ class TestChallengeAPI(unittest.TestCase):
         test_challenge_id = '12978'
         api_instance.add_tasks_to_challenge(test_geojson, test_challenge_id)
         mock_request.assert_called_once_with(
-            f'{self.url}'
-        )
+            f'{self.url}/challenge/12978/addTasks',
+            json=test_geojson,
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_create_virtual_challenge(self, mock_request, api_instance=api):
@@ -66,7 +66,9 @@ class TestChallengeAPI(unittest.TestCase):
                                                           overpassQL=test_overpassQL_query)
         api_instance.create_virtual_challenge(test_challenge_model)
         mock_request.assert_called_once_with(
-            f'{self.url}'
+            f'{self.url}/virtualchallenge',
+            json=test_challenge_model,
+            params=None
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
@@ -75,7 +77,8 @@ class TestChallengeAPI(unittest.TestCase):
         test_challenge_name = 'Test_Challenge_Name'
         api_instance.get_challenge_by_name(test_project_id, test_challenge_name)
         mock_request.assert_called_once_with(
-            f'{self.url}'
+            f'{self.url}/project/{test_project_id}/challenge/{test_challenge_name}',
+            params=None
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
@@ -83,7 +86,8 @@ class TestChallengeAPI(unittest.TestCase):
         test_virtual_challenge_id = '12345'
         api_instance.get_virtual_challenge_by_id(test_virtual_challenge_id)
         mock_request.assert_called_once_with(
-            f'{self.url}'
+            f'{self.url}/virtualchallenge/{test_virtual_challenge_id}',
+            params=None
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
@@ -91,31 +95,38 @@ class TestChallengeAPI(unittest.TestCase):
         test_project_ids = '12345,67891,23456'
         api_instance.get_challenge_listing(test_project_ids)
         mock_request.assert_called_once_with(
-            f'{self.url}'
-        )
+            f'{self.url}/challenges/listing',
+            params={'projectIds': test_project_ids,
+                    'limit': '10',
+                    'page': '0',
+                    'onlyEnabled': 'true'})
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_children(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
         api_instance.get_challenge_children(test_challenge_id)
         mock_request.assert_called_once_with(
-            f'{self.url}'
-        )
+            f'{self.url}/challenge/{test_challenge_id}/children',
+            params={'limit': '10',
+                    'page': '0'})
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_comments(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
         api_instance.get_challenge_comments(test_challenge_id)
         mock_request.assert_called_once_with(
-            f'{self.url}'
-        )
+            f'{self.url}/challenge/{test_challenge_id}/comments',
+            params={'limit': '10',
+                    'page': '0'})
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_extract_challenge_comments(self, mock_request, api_instance=api):
         test_challenge_id = '12345'
         api_instance.extract_challenge_comments(test_challenge_id)
         mock_request.assert_called_once_with(
-            f'{self.url}'
+            f'{self.url}/challenge/{test_challenge_id}/comments/extract',
+            params={'limit': '10',
+                    'page': '0'}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
@@ -123,7 +134,14 @@ class TestChallengeAPI(unittest.TestCase):
         test_challenge_id = '12345'
         api_instance.extract_task_summaries(test_challenge_id)
         mock_request.assert_called_once_with(
-            f'{self.url}'
+            f'{self.url}/challenge/{test_challenge_id}/tasks/extract',
+            params={'limit': '10',
+                    'page': '0',
+                    'status': "",
+                    'reviewStatus': "",
+                    'priority': "",
+                    'exportProperties': "",
+                    'taskPropertySearch': ""}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
@@ -131,7 +149,11 @@ class TestChallengeAPI(unittest.TestCase):
         test_challenge_id = '12345'
         api_instance.get_challenge_geojson(test_challenge_id)
         mock_request.assert_called_once_with(
-            f'{self.url}'
+            f'{self.url}/challenge/view/{test_challenge_id}',
+            params={'status': "",
+                    'reviewStatus': "",
+                    'priority': "",
+                    'taskPropertySearch': ""}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
@@ -139,7 +161,9 @@ class TestChallengeAPI(unittest.TestCase):
         test_challenge_id = '12345'
         api_instance.update_task_priorities(test_challenge_id)
         mock_request.assert_called_once_with(
-            f'{self.url}'
+            f'{self.url}/challenge/{test_challenge_id}/updateTaskPriorities',
+            json=None,
+            params=None
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
@@ -147,7 +171,9 @@ class TestChallengeAPI(unittest.TestCase):
         test_challenge_id = '12345'
         api_instance.reset_task_instructions(test_challenge_id)
         mock_request.assert_called_once_with(
-            f'{self.url}'
+            f'{self.url}/challenge/{test_challenge_id}/resetTaskInstructions',
+            json=None,
+            params=None
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.delete')
@@ -155,7 +181,8 @@ class TestChallengeAPI(unittest.TestCase):
         test_challenge_id = '12345'
         api_instance.delete_challenge(test_challenge_id)
         mock_request.assert_called_once_with(
-            f'{self.url}'
+            f'{self.url}/challenge/{test_challenge_id}',
+            params={'immediate': 'false'}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.delete')
@@ -163,7 +190,8 @@ class TestChallengeAPI(unittest.TestCase):
         test_challenge_id = '12345'
         api_instance.delete_challenge_tasks(test_challenge_id)
         mock_request.assert_called_once_with(
-            f'{self.url}'
+            f'{self.url}/challenge/{test_challenge_id}/tasks',
+            params={'statusFilters': ""}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
@@ -175,5 +203,7 @@ class TestChallengeAPI(unittest.TestCase):
                                                           overpassQL=test_overpassQL_query)
         api_instance.update_challenge(test_challenge_id, test_challenge_model)
         mock_request.assert_called_once_with(
-            f'{self.url}'
+            f'{self.url}/challenge/{test_challenge_id}',
+            json=json.loads(create_challenge_output),
+            params=None
         )

--- a/tests/test_challenge_api.py
+++ b/tests/test_challenge_api.py
@@ -68,8 +68,7 @@ class TestChallengeAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/virtualchallenge',
             json=test_challenge_model,
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_by_name(self, mock_request, api_instance=api):
@@ -78,8 +77,7 @@ class TestChallengeAPI(unittest.TestCase):
         api_instance.get_challenge_by_name(test_project_id, test_challenge_name)
         mock_request.assert_called_once_with(
             f'{self.url}/project/{test_project_id}/challenge/{test_challenge_name}',
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_virtual_challenge_by_id(self, mock_request, api_instance=api):
@@ -87,8 +85,7 @@ class TestChallengeAPI(unittest.TestCase):
         api_instance.get_virtual_challenge_by_id(test_virtual_challenge_id)
         mock_request.assert_called_once_with(
             f'{self.url}/virtualchallenge/{test_virtual_challenge_id}',
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_listing(self, mock_request, api_instance=api):
@@ -126,8 +123,7 @@ class TestChallengeAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/challenge/{test_challenge_id}/comments/extract',
             params={'limit': '10',
-                    'page': '0'}
-        )
+                    'page': '0'})
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_extract_task_summaries(self, mock_request, api_instance=api):
@@ -141,8 +137,7 @@ class TestChallengeAPI(unittest.TestCase):
                     'reviewStatus': '',
                     'priority': '',
                     'exportProperties': '',
-                    'taskPropertySearch': ''}
-        )
+                    'taskPropertySearch': ''})
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_challenge_geojson(self, mock_request, api_instance=api):
@@ -153,8 +148,7 @@ class TestChallengeAPI(unittest.TestCase):
             params={'status': '',
                     'reviewStatus': '',
                     'priority': '',
-                    'taskPropertySearch': ''}
-        )
+                    'taskPropertySearch': ''})
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_update_task_priorities(self, mock_request, api_instance=api):
@@ -163,8 +157,7 @@ class TestChallengeAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/challenge/{test_challenge_id}/updateTaskPriorities',
             json=None,
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_reset_task_instructions(self, mock_request, api_instance=api):
@@ -173,8 +166,7 @@ class TestChallengeAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/challenge/{test_challenge_id}/resetTaskInstructions',
             json=None,
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.delete')
     def test_delete_challenge(self, mock_request, api_instance=api):
@@ -182,8 +174,7 @@ class TestChallengeAPI(unittest.TestCase):
         api_instance.delete_challenge(test_challenge_id)
         mock_request.assert_called_once_with(
             f'{self.url}/challenge/{test_challenge_id}',
-            params={'immediate': 'false'}
-        )
+            params={'immediate': 'false'})
 
     @patch('maproulette.api.maproulette_server.requests.Session.delete')
     def test_delete_challenge_tasks(self, mock_request, api_instance=api):
@@ -191,8 +182,7 @@ class TestChallengeAPI(unittest.TestCase):
         api_instance.delete_challenge_tasks(test_challenge_id)
         mock_request.assert_called_once_with(
             f'{self.url}/challenge/{test_challenge_id}/tasks',
-            params={'statusFilters': ''}
-        )
+            params={'statusFilters': ''})
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_update_challenge(self, mock_request, api_instance=api):
@@ -205,5 +195,4 @@ class TestChallengeAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/challenge/{test_challenge_id}',
             json=json.loads(create_challenge_output),
-            params=None
-        )
+            params=None)

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -1,6 +1,6 @@
 import maproulette
 import unittest
-from tests.sample_data import test_geojson, test_overpassQL_query
+from tests.sample_data import test_project
 from unittest.mock import patch
 
 
@@ -8,42 +8,59 @@ class TestProjectAPI(unittest.TestCase):
 
     config = maproulette.Configuration(api_key="API_KEY")
     api = maproulette.Project(config)
+    url = config.api_url
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_project_by_id(self, mock_request, api_instance=api):
         test_project_id = '32922'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_project_by_id(test_project_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_project_by_id(test_project_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/project/{test_project_id}',
+            params=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_project_by_name(self, mock_request, api_instance=api):
         test_project_name = 'Maptime!'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_project_by_name(test_project_name)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_project_by_name(test_project_name)
+        mock_request.assert_called_once_with(
+            f'{self.url}/projectByName/{test_project_name}',
+            params=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_find_project(self, mock_request, api_instance=api):
         test_search = 'Health Facilities in India'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.find_project(test_search)
-        self.assertEqual(response['status'], '200')
+        api_instance.find_project(test_search)
+        mock_request.assert_called_once_with(
+            f'{self.url}/projects',
+            params={"search": test_search,
+                    "limit": "10",
+                    "page": "0",
+                    "onlyEnabled": "true"
+                    }
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_project_challenges(self, mock_request, api_instance=api):
         test_project_id = '12974'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_project_challenges(test_project_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_project_challenges(test_project_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/project/{test_project_id}/challenges',
+            params={"limit": "10",
+                    "page": "0"}
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_create_project(self, mock_request, api_instance=api):
         test_project_model = maproulette.ProjectModel(name='Test_Project_Name',
                                                       description='This is a test project')
-        mock_request.return_value.status_code = '200'
-        response = api_instance.create_project(test_project_model)
-        self.assertEqual(response['status'], '200')
+        api_instance.create_project(test_project_model)
+        mock_request.assert_called_once_with(
+            f'{self.url}/project',
+            json=test_project,
+            params=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_add_challenge_to_project(self, mock_request, api_instance=api):
@@ -53,9 +70,12 @@ class TestProjectAPI(unittest.TestCase):
                                                           id=246)
         test_virtual_project_id = test_virtual_project_model.id
         test_challenge_id = test_challenge_model.id
-        mock_request.return_value.status_code = '200'
-        response = api_instance.add_challenge_to_project(test_virtual_project_id, test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.add_challenge_to_project(test_virtual_project_id, test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/project/{test_virtual_project_id}/challenge/{test_challenge_id}/add',
+            json=None,
+            params=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_remove_challenge_from_project(self, mock_request, api_instance=api):
@@ -64,39 +84,54 @@ class TestProjectAPI(unittest.TestCase):
         test_challenge_model = maproulette.ChallengeModel(name='Test Challenge Name', id=246)
         test_virtual_project_id = test_virtual_project_model.id
         test_challenge_id = test_challenge_model.id
-        mock_request.return_value.status_code = '200'
-        response = api_instance.remove_challenge_from_project(test_virtual_project_id, test_challenge_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.remove_challenge_from_project(test_virtual_project_id, test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/project/{test_virtual_project_id}/challenge/{test_challenge_id}/remove',
+            json=None,
+            params=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.delete')
     def test_delete_project(self, mock_request, api_instance=api):
         test_project_model = maproulette.ProjectModel(name='Test Project Name', id=1234)
         test_project_id = test_project_model.id
-        mock_request.return_value.status_code = '200'
-        response = api_instance.delete_project(test_project_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.delete_project(test_project_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/project/{test_project_id}',
+            params=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_update_project(self, mock_request, api_instance=api):
         test_project_model = maproulette.ProjectModel(name='Test Project Name', id=1234)
-        test_updated_project_model = maproulette.ProjectModel(name='Test Updated Project Name')
+        test_updated_project_name = 'Test Updated Project Name'
+        test_updated_project_model = maproulette.ProjectModel(name=test_updated_project_name)
         test_project_model_id = test_project_model.id
-        mock_request.return_value.status_code = '200'
-        response = api_instance.update_project(test_project_model_id, test_updated_project_model)
-        self.assertEqual(response['status'], '200')
+        api_instance.update_project(test_project_model_id, test_updated_project_model)
+        mock_request.assert_called_once_with(
+            f'{self.url}/project/{test_project_model_id}',
+            json={'name': test_updated_project_name},
+            params=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_project_by_ids(self, mock_request, api_instance=api):
         test_project_ids = '1234,2468,1356'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_projects_by_ids(test_project_ids)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_projects_by_ids(test_project_ids)
+        mock_request.assert_called_once_with(
+            f'{self.url}/projectsById',
+            params={"projectIds": test_project_ids}
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_random_tasks(self, mock_request, api_instance=api):
         test_project_model = maproulette.ProjectModel(name='Test Project Name',
                                                       id=1234)
         test_project_id = test_project_model.id
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_random_tasks(test_project_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_random_tasks(test_project_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/project/{test_project_id}/tasks',
+            params={"limit": "1",
+                    "proximity": "-1",
+                    "search": ""}
+        )

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -34,10 +34,10 @@ class TestProjectAPI(unittest.TestCase):
         api_instance.find_project(test_search)
         mock_request.assert_called_once_with(
             f'{self.url}/projects',
-            params={"search": test_search,
-                    "limit": "10",
-                    "page": "0",
-                    "onlyEnabled": "true"
+            params={'search': test_search,
+                    'limit': '10',
+                    'page': '0',
+                    'onlyEnabled': 'true'
                     }
         )
 
@@ -47,8 +47,8 @@ class TestProjectAPI(unittest.TestCase):
         api_instance.get_project_challenges(test_project_id)
         mock_request.assert_called_once_with(
             f'{self.url}/project/{test_project_id}/challenges',
-            params={"limit": "10",
-                    "page": "0"}
+            params={'limit': '10',
+                    'page': '0'}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
@@ -120,7 +120,7 @@ class TestProjectAPI(unittest.TestCase):
         api_instance.get_projects_by_ids(test_project_ids)
         mock_request.assert_called_once_with(
             f'{self.url}/projectsById',
-            params={"projectIds": test_project_ids}
+            params={'projectIds': test_project_ids}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
@@ -131,7 +131,7 @@ class TestProjectAPI(unittest.TestCase):
         api_instance.get_random_tasks(test_project_id)
         mock_request.assert_called_once_with(
             f'{self.url}/project/{test_project_id}/tasks',
-            params={"limit": "1",
-                    "proximity": "-1",
-                    "search": ""}
+            params={'limit': '1',
+                    'proximity': '-1',
+                    'search': ''}
         )

--- a/tests/test_project_api.py
+++ b/tests/test_project_api.py
@@ -16,8 +16,7 @@ class TestProjectAPI(unittest.TestCase):
         api_instance.get_project_by_id(test_project_id)
         mock_request.assert_called_once_with(
             f'{self.url}/project/{test_project_id}',
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_project_by_name(self, mock_request, api_instance=api):
@@ -25,8 +24,7 @@ class TestProjectAPI(unittest.TestCase):
         api_instance.get_project_by_name(test_project_name)
         mock_request.assert_called_once_with(
             f'{self.url}/projectByName/{test_project_name}',
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_find_project(self, mock_request, api_instance=api):
@@ -37,9 +35,7 @@ class TestProjectAPI(unittest.TestCase):
             params={'search': test_search,
                     'limit': '10',
                     'page': '0',
-                    'onlyEnabled': 'true'
-                    }
-        )
+                    'onlyEnabled': 'true'})
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_project_challenges(self, mock_request, api_instance=api):
@@ -48,8 +44,7 @@ class TestProjectAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/project/{test_project_id}/challenges',
             params={'limit': '10',
-                    'page': '0'}
-        )
+                    'page': '0'})
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_create_project(self, mock_request, api_instance=api):
@@ -59,8 +54,7 @@ class TestProjectAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/project',
             json=test_project,
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_add_challenge_to_project(self, mock_request, api_instance=api):
@@ -74,8 +68,7 @@ class TestProjectAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/project/{test_virtual_project_id}/challenge/{test_challenge_id}/add',
             json=None,
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_remove_challenge_from_project(self, mock_request, api_instance=api):
@@ -88,8 +81,7 @@ class TestProjectAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/project/{test_virtual_project_id}/challenge/{test_challenge_id}/remove',
             json=None,
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.delete')
     def test_delete_project(self, mock_request, api_instance=api):
@@ -98,8 +90,7 @@ class TestProjectAPI(unittest.TestCase):
         api_instance.delete_project(test_project_id)
         mock_request.assert_called_once_with(
             f'{self.url}/project/{test_project_id}',
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_update_project(self, mock_request, api_instance=api):
@@ -111,8 +102,7 @@ class TestProjectAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/project/{test_project_model_id}',
             json={'name': test_updated_project_name},
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_project_by_ids(self, mock_request, api_instance=api):
@@ -120,8 +110,7 @@ class TestProjectAPI(unittest.TestCase):
         api_instance.get_projects_by_ids(test_project_ids)
         mock_request.assert_called_once_with(
             f'{self.url}/projectsById',
-            params={'projectIds': test_project_ids}
-        )
+            params={'projectIds': test_project_ids})
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_random_tasks(self, mock_request, api_instance=api):
@@ -133,5 +122,4 @@ class TestProjectAPI(unittest.TestCase):
             f'{self.url}/project/{test_project_id}/tasks',
             params={'limit': '1',
                     'proximity': '-1',
-                    'search': ''}
-        )
+                    'search': ''})

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -1,4 +1,3 @@
-import json
 import maproulette
 import unittest
 from tests.sample_data import test_geojson
@@ -9,20 +8,25 @@ class TestTaskAPI(unittest.TestCase):
 
     config = maproulette.Configuration(api_key="API_KEY")
     api = maproulette.Task(config)
+    url = config.api_url
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_task_by_id(self, mock_request, api_instance=api):
         test_task_id = '42914448'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_task_by_id(test_task_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_task_by_id(test_task_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/task/{test_task_id}',
+            params=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_task_history(self, mock_request, api_instance=api):
         test_task_id = '42914448'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_task_history(test_task_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_task_history(test_task_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/task/{test_task_id}/history',
+            params=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_create_tasks(self, mock_request, api_instance=api):
@@ -32,10 +36,17 @@ class TestTaskAPI(unittest.TestCase):
                                                 parent='12345',
                                                 geometries=geometries)
         test_tasks.append(test_task_model.to_dict())
-        mock_request.return_value.status_code = '200'
-        responses = api_instance.create_tasks(test_tasks)
-        for response in responses:
-            self.assertEqual(response['status'], '200')
+        api_instance.create_tasks(test_tasks)
+        input_json_list = []
+        for task in test_tasks:
+            input_json_list.append({"name": task["name"],
+                                    "parent": task["parent"],
+                                    "geometries": task["geometries"]})
+        mock_request.assert_called_once_with(
+            f'{self.url}/tasks',
+            json=input_json_list,
+            params=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_update_tasks(self, mock_request, api_instance=api):
@@ -43,54 +54,75 @@ class TestTaskAPI(unittest.TestCase):
         test_task_model = maproulette.TaskModel(name='test_task',
                                                 parent='12345',
                                                 geometries=geometries)
-        mock_request.return_value.status_code = '200'
-        response = api_instance.update_tasks(test_task_model)
-        self.assertEqual(response['status'], '200')
+        api_instance.update_tasks(test_task_model)
+        mock_request.assert_called_once_with(
+            f'{self.url}/tasks',
+            json=test_task_model,
+            params=None
+        )
+
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_task_tags(self, mock_request, api_instance=api):
-        task_id = '42914448'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_task_tags(task_id)
-        self.assertEqual(response['status'], '200')
+        test_task_id = '42914448'
+        api_instance.get_task_tags(test_task_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/task/{test_task_id}/tags',
+            params=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.delete')
     def test_delete_task_tags(self, mock_request, api_instance=api):
         task_id = '42914448'
         tags = 'test'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.delete_task_tags(task_id, tags)
-        self.assertEqual(response['status'], '200')
+        api_instance.delete_task_tags(task_id, tags)
+        mock_request.assert_called_once_with(
+            f'{self.url}/task/{task_id}/tags',
+            params={"tags": tags}
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_tasks_by_tags(self, mock_request, api_instance=api):
         tags = 'test'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_tasks_by_tags(tags)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_tasks_by_tags(tags)
+        mock_request.assert_called_once_with(
+            f'{self.url}/tasks/tags',
+            params={"tags": tags,
+                    "limit": "10",
+                    "page": "0"}
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_update_task_tags(self, mock_request, api_instance=api):
         task_id = '42914448'
         tags = 'test'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.update_task_tags(task_id, tags)
-        self.assertEqual(response['status'], '200')
+        api_instance.update_task_tags(task_id, tags)
+        mock_request.assert_called_once_with(
+            f'{self.url}/task/{task_id}/tags/update',
+            params={"tags": tags}
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_update_task_status(self, mock_request, api_instance=api):
         task_id = '42914448'
         status = 3
-        mock_request.return_value.status_code = '200'
-        response = api_instance.update_task_status(task_id, status)
-        self.assertEqual(response['status'], '200')
+        api_instance.update_task_status(task_id, status)
+        mock_request.assert_called_once_with(
+            f'{self.url}/task/{task_id}/{status}',
+            params={"comment": "None",
+                    "tags": "None",
+                    "requestReview": "None"},
+            json=None
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_task_comments(self, mock_request, api_instance=api):
         task_id = '42914448'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.get_task_comments(task_id)
-        self.assertEqual(response['status'], '200')
+        api_instance.get_task_comments(task_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/task/{task_id}/comments',
+            params=None
+        )
 
     def test_batch_generator(self, api_instance=api):
 

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -39,9 +39,9 @@ class TestTaskAPI(unittest.TestCase):
         api_instance.create_tasks(test_tasks)
         input_json_list = []
         for task in test_tasks:
-            input_json_list.append({"name": task["name"],
-                                    "parent": task["parent"],
-                                    "geometries": task["geometries"]})
+            input_json_list.append({'name': task['name'],
+                                    'parent': task['parent'],
+                                    'geometries': task['geometries']})
         mock_request.assert_called_once_with(
             f'{self.url}/tasks',
             json=input_json_list,
@@ -78,7 +78,7 @@ class TestTaskAPI(unittest.TestCase):
         api_instance.delete_task_tags(task_id, tags)
         mock_request.assert_called_once_with(
             f'{self.url}/task/{task_id}/tags',
-            params={"tags": tags}
+            params={'tags': tags}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
@@ -87,9 +87,9 @@ class TestTaskAPI(unittest.TestCase):
         api_instance.get_tasks_by_tags(tags)
         mock_request.assert_called_once_with(
             f'{self.url}/tasks/tags',
-            params={"tags": tags,
-                    "limit": "10",
-                    "page": "0"}
+            params={'tags': tags,
+                    'limit': '10',
+                    'page': '0'}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
@@ -99,7 +99,7 @@ class TestTaskAPI(unittest.TestCase):
         api_instance.update_task_tags(task_id, tags)
         mock_request.assert_called_once_with(
             f'{self.url}/task/{task_id}/tags/update',
-            params={"tags": tags}
+            params={'tags': tags}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
@@ -109,9 +109,9 @@ class TestTaskAPI(unittest.TestCase):
         api_instance.update_task_status(task_id, status)
         mock_request.assert_called_once_with(
             f'{self.url}/task/{task_id}/{status}',
-            params={"comment": "None",
-                    "tags": "None",
-                    "requestReview": "None"},
+            params={'comment': 'None',
+                    'tags': 'None',
+                    'requestReview': 'None'},
             json=None
         )
 

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -16,8 +16,7 @@ class TestTaskAPI(unittest.TestCase):
         api_instance.get_task_by_id(test_task_id)
         mock_request.assert_called_once_with(
             f'{self.url}/task/{test_task_id}',
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_task_history(self, mock_request, api_instance=api):
@@ -25,8 +24,7 @@ class TestTaskAPI(unittest.TestCase):
         api_instance.get_task_history(test_task_id)
         mock_request.assert_called_once_with(
             f'{self.url}/task/{test_task_id}/history',
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_create_tasks(self, mock_request, api_instance=api):
@@ -45,8 +43,7 @@ class TestTaskAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/tasks',
             json=input_json_list,
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_update_tasks(self, mock_request, api_instance=api):
@@ -58,8 +55,7 @@ class TestTaskAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/tasks',
             json=test_task_model,
-            params=None
-        )
+            params=None)
 
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
@@ -68,8 +64,7 @@ class TestTaskAPI(unittest.TestCase):
         api_instance.get_task_tags(test_task_id)
         mock_request.assert_called_once_with(
             f'{self.url}/task/{test_task_id}/tags',
-            params=None
-        )
+            params=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.delete')
     def test_delete_task_tags(self, mock_request, api_instance=api):
@@ -78,8 +73,7 @@ class TestTaskAPI(unittest.TestCase):
         api_instance.delete_task_tags(task_id, tags)
         mock_request.assert_called_once_with(
             f'{self.url}/task/{task_id}/tags',
-            params={'tags': tags}
-        )
+            params={'tags': tags})
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_tasks_by_tags(self, mock_request, api_instance=api):
@@ -89,8 +83,7 @@ class TestTaskAPI(unittest.TestCase):
             f'{self.url}/tasks/tags',
             params={'tags': tags,
                     'limit': '10',
-                    'page': '0'}
-        )
+                    'page': '0'})
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_update_task_tags(self, mock_request, api_instance=api):
@@ -99,8 +92,7 @@ class TestTaskAPI(unittest.TestCase):
         api_instance.update_task_tags(task_id, tags)
         mock_request.assert_called_once_with(
             f'{self.url}/task/{task_id}/tags/update',
-            params={'tags': tags}
-        )
+            params={'tags': tags})
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_update_task_status(self, mock_request, api_instance=api):
@@ -112,8 +104,7 @@ class TestTaskAPI(unittest.TestCase):
             params={'comment': 'None',
                     'tags': 'None',
                     'requestReview': 'None'},
-            json=None
-        )
+            json=None)
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_get_task_comments(self, mock_request, api_instance=api):
@@ -121,8 +112,7 @@ class TestTaskAPI(unittest.TestCase):
         api_instance.get_task_comments(task_id)
         mock_request.assert_called_once_with(
             f'{self.url}/task/{task_id}/comments',
-            params=None
-        )
+            params=None)
 
     def test_batch_generator(self, api_instance=api):
 

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -7,34 +7,45 @@ class TestUserAPI(unittest.TestCase):
 
     config = maproulette.Configuration(api_key="API_KEY")
     api = maproulette.User(config)
+    url = config.api_url
 
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_find_user_by_username(self, mock_request, api_instance=api):
         test_username = 'my_username_123'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.find_user_by_username(test_username)
-        self.assertEqual(response['status'], '200')
+        api_instance.find_user_by_username(test_username)
+        mock_request.assert_called_once_with(
+            f'{self.url}/users/find/{test_username}',
+            params={"limit": "10",
+                    "page": "0"
+                    }
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_add_user_to_project(self, mock_request, api_instance=api):
         test_user_id = '12345'
         test_project_id = '6789'
         test_group = '2'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.add_user_to_project(user_id=test_user_id,
+        api_instance.add_user_to_project(user_id=test_user_id,
                                                     project_id=test_project_id,
                                                     group_type=test_group,
                                                     is_osm_user_id='true')
-        self.assertEqual(response['status'], '200')
+        mock_request.assert_called_once_with(
+            f'{self.url}/user/{test_user_id}/project/{test_project_id}/{test_group}',
+            json=None,
+            params={"isOSMUserId": "true"}
+        )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_add_user_list_to_project(self, mock_request, api_instance=api):
         test_user_ids = [123, 456, 789]
         test_project_id = '6789'
         test_group = '2'
-        mock_request.return_value.status_code = '200'
-        response = api_instance.add_user_list_to_project(user_ids=test_user_ids,
+        api_instance.add_user_list_to_project(user_ids=test_user_ids,
                                                          project_id=test_project_id,
                                                          group_type=test_group,
                                                          is_osm_user_id='true')
-        self.assertEqual(response['status'], '200')
+        mock_request.assert_called_once_with(
+            f'{self.url}/user/project/{test_project_id}/{test_group}',
+            params={"isOSMUserId": "true"},
+            json=test_user_ids
+        )

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -16,9 +16,7 @@ class TestUserAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/users/find/{test_username}',
             params={'limit': '10',
-                    'page': '0'
-                    }
-        )
+                    'page': '0'})
 
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_add_user_to_project(self, mock_request, api_instance=api):
@@ -32,8 +30,7 @@ class TestUserAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/user/{test_user_id}/project/{test_project_id}/{test_group}',
             json=None,
-            params={'isOSMUserId': 'true'}
-        )
+            params={'isOSMUserId': 'true'})
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
     def test_add_user_list_to_project(self, mock_request, api_instance=api):
@@ -47,5 +44,4 @@ class TestUserAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/user/project/{test_project_id}/{test_group}',
             params={'isOSMUserId': 'true'},
-            json=test_user_ids
-        )
+            json=test_user_ids)

--- a/tests/test_user_api.py
+++ b/tests/test_user_api.py
@@ -15,8 +15,8 @@ class TestUserAPI(unittest.TestCase):
         api_instance.find_user_by_username(test_username)
         mock_request.assert_called_once_with(
             f'{self.url}/users/find/{test_username}',
-            params={"limit": "10",
-                    "page": "0"
+            params={'limit': '10',
+                    'page': '0'
                     }
         )
 
@@ -32,7 +32,7 @@ class TestUserAPI(unittest.TestCase):
         mock_request.assert_called_once_with(
             f'{self.url}/user/{test_user_id}/project/{test_project_id}/{test_group}',
             json=None,
-            params={"isOSMUserId": "true"}
+            params={'isOSMUserId': 'true'}
         )
 
     @patch('maproulette.api.maproulette_server.requests.Session.put')
@@ -46,6 +46,6 @@ class TestUserAPI(unittest.TestCase):
                                                          is_osm_user_id='true')
         mock_request.assert_called_once_with(
             f'{self.url}/user/project/{test_project_id}/{test_group}',
-            params={"isOSMUserId": "true"},
+            params={'isOSMUserId': 'true'},
             json=test_user_ids
         )


### PR DESCRIPTION
### Description:
This PR adjusts the existing unit tests to assert the expected API call using assert_called_once_with() rather than assigning a passing status code to the mocked response. This approach provides a more robust check for each endpoint to assure that software changes do not adversely affect the API call itself. 

### Potential Impact:
All tests should still pass as expected. Future software changes that affect individual API calls will require adjustments to the corresponding unit test

### Unit Test Approach:
Running all unit tests

### Test Results:
Tests pass
