### PR TITLE
Added new endpoint for fetching tasks by bounding box

### DIFF
--- a/maproulette/api/task.py
+++ b/maproulette/api/task.py
@@ -102,6 +102,38 @@ class Task(MapRouletteServer):
         )
         return response
 
+    def get_tasks_by_bounding_box(self, left, bottom, right, top, limit=10000, page=0, exclude_locked="false",
+                                  order="ASC", include_total="false", include_geometries="false", include_tags="false"):
+        """Method to retrieve tasks by a bounding box defined by left, bottom, right, and top lat/long values
+
+        :param left: the minimum latitude of the bounding box
+        :param bottom: the minimum longitude of the bounding box
+        :param right: the maximum latitude of the bounding box
+        :param top: the maximum longitude of the bounding box
+        :param limit: the limit to the number of results returned in the response. Default is 10,000.
+        :param page: used in conjunction with the limit parameter to page through X number of responses. Default is 0.
+        :param exclude_locked: boolean indicating whether to exclude locked tasks. Default is 'false'.
+        :param order: the order of the results. Default is 'ASC'
+        :param include_total: whether to include total or not. Default is 'false'
+        :param include_geometries: whether to include geometries or not. Default is 'false'
+        :param include_tags: whether to include tags or not. Default is 'false'
+        :return: the API response from the PUT request
+        """
+        query_params = {
+            "limit": str(limit),
+            "page": str(page),
+            "excludeLocked": str(exclude_locked),
+            "order": str(order),
+            "includeTotal": str(include_total),
+            "includeGeometries": str(include_geometries),
+            "includeTags": str(include_tags)
+        }
+        response = self.put(
+            endpoint=f'/tasks/box/{left}/{bottom}/{right}/{top}',
+            params=query_params
+        )
+        return response
+
     def update_task_tags(self, task_id, tags):
         """Method to update a task's tags using the supplied tags and corresponding task ID
 

--- a/tests/test_task_api.py
+++ b/tests/test_task_api.py
@@ -85,6 +85,30 @@ class TestTaskAPI(unittest.TestCase):
                     'limit': '10',
                     'page': '0'})
 
+    @patch('maproulette.api.maproulette_server.requests.Session.put')
+    def test_get_tasks_by_bounding_box(self, mock_request, api_instance=api):
+        left = -1.22321018
+        bottom = 47.690315
+        right = -122.306191
+        top = 47.706912
+        api_instance.get_tasks_by_bounding_box(
+            left=left,
+            bottom=bottom,
+            right=right,
+            top=top
+        )
+        mock_request.assert_called_once_with(
+            f'{self.url}/tasks/box/{left}/{bottom}/{right}/{top}',
+            json=None,
+            params={
+                "limit": '10000',
+                "page": '0',
+                "excludeLocked": 'false',
+                "order": 'ASC',
+                "includeTotal": 'false',
+                "includeGeometries": 'false',
+                "includeTags": 'false'})
+
     @patch('maproulette.api.maproulette_server.requests.Session.get')
     def test_update_task_tags(self, mock_request, api_instance=api):
         task_id = '42914448'


### PR DESCRIPTION
### Description:
This PR adds support for [fetching tasks by bounding box](https://maproulette.org/docs/swagger-ui/index.html?url=/assets/swagger.json#/Task/getTasksInBoundingBox). 

### Potential Impact:
N/A

### Unit Test Approach:
Tox passing

### Test Results:
Tested this endpoint by fetching tasks for a small bounding box in Seattle, WA:
```python

# Creating bounding box
left = -1.22321018
bottom = 47.690315
right = -122.306191
top = 47.706912

print(json.dumps(api.get_tasks_by_bounding_box(
    left=left,
    bottom=bottom,
    right=right,
    top=top
)))
```
The output can be found in the file below: 

[bb_response.json.zip](https://github.com/osmlab/maproulette-python-client/files/5431651/bb_response.json.zip)

