### PR TITLE
add info where API KEY can be found

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ that when you create your configuration. For example:
 config = maproulette.Configuration(api_key='{YOUR_API_KEY}')
 ```
 
+Your API KEY is listed at the bottom of https://maproulette.org/user/profile page.
+
 Once you have your configuration object we can create an API object using one of several modules depending on the
 functionality that the user is looking for. For example, creating a Project object allows the user to interact with all
 of the project-related functionality in the MapRoulette package.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ that when you create your configuration. For example:
 config = maproulette.Configuration(api_key='{YOUR_API_KEY}')
 ```
 
-Your API KEY is listed at the bottom of https://maproulette.org/user/profile page.
+Your API key is listed at the bottom of https://maproulette.org/user/profile page.
 
 Once you have your configuration object we can create an API object using one of several modules depending on the
 functionality that the user is looking for. For example, creating a Project object allows the user to interact with all


### PR DESCRIPTION
### Description:

Added "Your API KEY is listed at the bottom of https://maproulette.org/user/profile page." in quickstart in the readme.

### Potential Impact:

None

### Unit Test Approach:

Not needed.

### Test Results:

Not relevant.