### PR TITLE
Add endpoint to rebuild challenge

### DIFF
--- a/maproulette/api/challenge.py
+++ b/maproulette/api/challenge.py
@@ -325,6 +325,23 @@ class Challenge(MapRouletteServer):
             body=data)
         return response
 
+    def rebuild_challenge(self, challenge_id, remove_unmatched=False, skip_snapshot=False):
+        """Rebuild the challenge by re-creating the tasks from the task data source
+
+        :param challenge_id: the ID corresponding to the challenge
+        :param remove_unmatched: Used to remove incomplete tasks that have been addressed externally since the last
+            rebuild, assuming the source data represents all tasks outstanding. If set to true, all existing tasks in
+            CREATED or SKIPPED status (only) will be removed prior to rebuilding with the assumption that they will be
+            recreated if they still appear in the updated source data. If set to false, unmatched existing tasks are
+            simply left as-is. Default: False
+        :param skipSnapshot: Whether to skip recording a snapshot before proceeding. Default: False
+        """
+        response = self.put(
+            endpoint=f"/challenge/{challenge_id}/rebuild",
+            params={'removeUnmatched': str(remove_unmatched).lower(), 'skipSnapshot': str(skip_snapshot).lower()}
+        )
+        return response
+
     @staticmethod
     def is_challenge_model(input_object):
         """Method to determine whether user input is a valid challenge model

--- a/tests/test_challenge_api.py
+++ b/tests/test_challenge_api.py
@@ -203,3 +203,12 @@ class TestChallengeAPI(unittest.TestCase):
             f'{self.url}/challenge/{test_challenge_id}',
             json=json.loads(create_challenge_output),
             params=None)
+
+    @patch('maproulette.api.maproulette_server.requests.Session.put')
+    def test_rebuild_challenge(self, mock_request, api_instance=api):
+        test_challenge_id = '12345'
+        api_instance.rebuild_challenge(test_challenge_id, True, True)
+        mock_request.assert_called_once_with(
+            f'{self.url}/challenge/{test_challenge_id}/rebuild',
+            params={'removeUnmatched': 'true', 'skipSnapshot': 'true'},
+            json=None)


### PR DESCRIPTION
Add the call to rebuild a challenge by ID.

### Description:

There’s an API call to update an existing challenge that was build with an Overpass query or remote GeoJSON by re-downloading the task objects. This is useful to update the challenge in one call when the source was updated.

This is the same as pressing “Rebuild Tasks” in the Maproulette Manage Challenge UI.

https://maproulette.org/docs/swagger-ui/index.html?url=/assets/swagger.json#/Challenge/rebuildChallenge

### Potential Impact:

Don’t see any impact on other users. This adds an optional method which maps 1:1 to the API.

### Unit Test Approach:

One unit test was added which checks that the mocked API endpoint gets called with the expected parameters.

### Test Results:

I’ve used this code to refresh a list of my own Maproulette challenges. It seems to work well, but the call may fail with a status 504 Gateway Timeout. I think this happens when the challenge is too large and the slow deletion of existing tasks doesn’t finish in the timeout. The challenge will then be rebuilt in the background anyway.