### PR TITLE
Changed response handling in case of JSON deserializing error

### DIFF
--- a/maproulette/api/challenge.py
+++ b/maproulette/api/challenge.py
@@ -334,7 +334,7 @@ class Challenge(MapRouletteServer):
             CREATED or SKIPPED status (only) will be removed prior to rebuilding with the assumption that they will be
             recreated if they still appear in the updated source data. If set to false, unmatched existing tasks are
             simply left as-is. Default: False
-        :param skipSnapshot: Whether to skip recording a snapshot before proceeding. Default: False
+        :param skip_snapshot: Whether to skip recording a snapshot before proceeding. Default: False
         """
         response = self.put(
             endpoint=f"/challenge/{challenge_id}/rebuild",

--- a/maproulette/api/maproulette_server.py
+++ b/maproulette/api/maproulette_server.py
@@ -54,7 +54,8 @@ class MapRouletteServer:
 
         :param endpoint: the server endpoint to use for the GET request
         :param params: the parameters that pertain to the request (optional)
-        :returns: a JSON object containing the API response
+        :returns: a dictionary containing the API response status code as well as the decoded JSON response if decoding
+            was successful. If not, the response text is returned.
         """
         response = self.session.get(
             self.url + endpoint,
@@ -85,6 +86,7 @@ class MapRouletteServer:
             }
         except ValueError:
             return {
+                "data": response.text,
                 "status": response.status_code
             }
 
@@ -94,7 +96,8 @@ class MapRouletteServer:
         :param endpoint: the server endpoint to use for the POST request
         :param body: the body of the request (optional)
         :param params: the parameters that pertain to the request (optional)
-        :returns: a JSON object containing the API response
+        :returns: a dictionary containing the API response status code as well as the decoded JSON response if decoding
+            was successful. If not, the response text is returned.
         """
         response = self.session.post(
             self.url + endpoint,
@@ -128,6 +131,7 @@ class MapRouletteServer:
             }
         except ValueError:
             return {
+                "data": response.text,
                 "status": response.status_code
             }
 
@@ -137,7 +141,8 @@ class MapRouletteServer:
         :param endpoint: the server endpoint to use for the PUT request
         :param body: the body of the request (optional)
         :param params: the parameters that pertain to the request (optional)
-        :returns: a JSON object containing the response code and the API response if
+        :returns: a dictionary containing the API response status code as well as the decoded JSON response if decoding
+            was successful. If not, the response text is returned.
         """
         response = self.session.put(
             self.url + endpoint,
@@ -171,6 +176,7 @@ class MapRouletteServer:
             }
         except ValueError:
             return {
+                "data": response.text,
                 "status": response.status_code
             }
 
@@ -179,7 +185,8 @@ class MapRouletteServer:
 
         :param endpoint: the server endpoint to use for the DELETE request
         :param params: the parameters that pertain to the request (optional)
-        :returns: a JSON object containing the API response
+        :returns: a dictionary containing the API response status code as well as the decoded JSON response if decoding
+            was successful. If not, the response text is returned.
         """
         response = self.session.delete(
             self.url + endpoint,
@@ -212,6 +219,7 @@ class MapRouletteServer:
             }
         except ValueError:
             return {
+                "data": response.text,
                 "status": response.status_code
             }
 


### PR DESCRIPTION
### Description:
This PR refactors the response dictionary that is created by the various `get`, `post`, `put`, and `delete` methods in maproulette_server.py. Originally, the response dictionary would contain both the status code and the `response.json()` object if it could successfully decode the JSON. If decoding failed, the response dictionary would contain only the status code. I've now included the `response.text` object in the response dictionary in the cases where the JSON cannot be decoded. 

This has an important impact on the `extract_task_summaries` method. This method is supposed to return a CSV payload of task summaries. However, this payload is returned in the `response.text` object. This change allows the user to access this payload just as they normally would for other methods by using the resulting `response['data']` object that is created from the `get` request.

I also made a small nit edit to some docstrings that I didn't catch previously.

### Potential Impact:
Makes the `extract_task_summaries` method usable. I don't think that this has any adverse impact on functionality since the `response.text` object will only be delivered in the cases of JSON decoding failing. In those cases, we only delivered the status code, so in my opinion this is an enhancement that shouldn't break anything. 

### Unit Test Approach:
N/A

### Test Results:
Tox tests are passing.
