### PR TITLE
Encode slashes in challenge_name

### DIFF
--- a/maproulette/api/challenge.py
+++ b/maproulette/api/challenge.py
@@ -51,7 +51,7 @@ class Challenge(MapRouletteServer):
         :param challenge_name: the name corresponding to the challenge
         :returns: the API response from the GET request
         """
-        response = self.get(endpoint=f"/project/{project_id}/challenge/{challenge_name}")
+        response = self.get(endpoint=f"/project/{project_id}/challenge/{challenge_name.replace('/', '%2F')}")
         return response
 
     def get_challenges_by_tags(self, challenge_tags, limit=10, page=0):


### PR DESCRIPTION
### Description:
A slash in the `challenge_name` of a MapRoulette challenge is valid and therefore has to be encoded. `requests` can't do this for us because we pass it the full URL (which contains slashes that must not be encoded).

### Potential Impact:
This doesn't impact previously working code at all.


### Test Results:
All tests pass.
`Note:` I had to change `envlist` in `tox.ini` to py38.