### PR TITLE
Add support for the endpoint /challenge/{id}/addFileTasks, closes #83

### DIFF
--- a/maproulette/api/challenge.py
+++ b/maproulette/api/challenge.py
@@ -284,6 +284,8 @@ class Challenge(MapRouletteServer):
         :param data: a GeoJSON containing geometry of tasks to be added to a challenge
         :param challenge_id: the ID corresponding to the challenge that tasks will be added to
         :param lineByLine: whether or not the provided data is in line-by-line GeoJSON format
+        :param remove_unmatched: whether or not the JSON provided includes seperate GeoJSON on each line
+        :param data_origin_date: the date the data was sourced on
         :param skipSnapshot: whether or not to skip recording a snapshot before proceeding
         :returns: the API response from the PUT request
         """

--- a/maproulette/api/challenge.py
+++ b/maproulette/api/challenge.py
@@ -278,6 +278,29 @@ class Challenge(MapRouletteServer):
             body=data)
         return response
 
+    def add_file_tasks_to_challenge(self, data, challenge_id, line_by_line="true", remove_unmatched="false", data_origin_date="", skip_snapshot="false"):
+        """Method to add tasks to an existing challenge with tasks as GeoJSON
+
+        :param data: a GeoJSON containing geometry of tasks to be added to a challenge
+        :param challenge_id: the ID corresponding to the challenge that tasks will be added to
+        :param lineByLine: whether or not the provided data is in line-by-line GeoJSON format
+        :param skipSnapshot: whether or not to skip recording a snapshot before proceeding
+        :returns: the API response from the PUT request
+        """
+        query_params = {
+            "lineByLine": str(line_by_line),
+            "removeUnmatched": str(remove_unmatched),
+            "dataOriginDate": str(data_origin_date),
+            "skipSnapshot": str(skip_snapshot)
+        }
+        body = {'json': ('data', data)} # server only accepts dict with key 'json'
+
+        response = self.put_file(
+            endpoint=f"/challenge/{challenge_id}/addFileTasks",
+            body=body,
+            params=query_params)
+        return response
+
     def delete_challenge(self, challenge_id, immediate="false"):
         """Method to delete a challenge by using the corresponding challenge ID
 

--- a/maproulette/api/challenge.py
+++ b/maproulette/api/challenge.py
@@ -283,10 +283,10 @@ class Challenge(MapRouletteServer):
 
         :param data: a GeoJSON containing geometry of tasks to be added to a challenge
         :param challenge_id: the ID corresponding to the challenge that tasks will be added to
-        :param lineByLine: whether or not the provided data is in line-by-line GeoJSON format
+        :param line_by_line: whether or not the provided data is in line-by-line GeoJSON format
         :param remove_unmatched: whether or not the JSON provided includes seperate GeoJSON on each line
         :param data_origin_date: the date the data was sourced on
-        :param skipSnapshot: whether or not to skip recording a snapshot before proceeding
+        :param skip_snapshot: whether or not to skip recording a snapshot before proceeding
         :returns: the API response from the PUT request
         """
         query_params = {

--- a/maproulette/api/challenge.py
+++ b/maproulette/api/challenge.py
@@ -278,7 +278,8 @@ class Challenge(MapRouletteServer):
             body=data)
         return response
 
-    def add_file_tasks_to_challenge(self, data, challenge_id, line_by_line="true", remove_unmatched="false", data_origin_date="", skip_snapshot="false"):
+    def add_file_tasks_to_challenge(self, data, challenge_id, line_by_line="true", remove_unmatched="false",
+                                    data_origin_date="", skip_snapshot="false"):
         """Method to add tasks to an existing challenge with tasks as GeoJSON
 
         :param data: a GeoJSON containing geometry of tasks to be added to a challenge

--- a/tests/test_challenge_api.py
+++ b/tests/test_challenge_api.py
@@ -57,6 +57,22 @@ class TestChallengeAPI(unittest.TestCase):
             json=test_geojson,
             params=None)
 
+    @patch('maproulette.api.maproulette_server.requests.Session.put')
+    def test_add_file_tasks_to_challenge(self, mock_request, api_instance=api):
+        test_challenge_id = '12978'
+        data = {'json': ('data', test_geojson)}
+        query_params = {
+            "lineByLine": "true",
+            "removeUnmatched": "false",
+            "dataOriginDate": "",
+            "skipSnapshot": "false"
+        }
+        api_instance.add_file_tasks_to_challenge(test_geojson, test_challenge_id)
+        mock_request.assert_called_once_with(
+            f'{self.url}/challenge/12978/addFileTasks',
+            files=data,
+            params=query_params)
+
     @patch('maproulette.api.maproulette_server.requests.Session.post')
     def test_create_virtual_challenge(self, mock_request, api_instance=api):
         # TODO: add model for virtual challenge to aid in posting


### PR DESCRIPTION
This is my shot at implementing the endpoint I requested in #83.

I have used the [swagger documentation](https://maproulette.org/docs/swagger-ui/index.html?url=/assets/swagger.json&docExpansion=none#/Challenge/addTasksToChallengeFromFile) for this.

Unfortuantely the API always returns `maproulette.api.errors.InvalidJsonError: {'status': 400, 'message': 'Invalid JSON payload.'}` no matter what I try. I have depleted my ideas for how to fix this, hence I'm creating this draft in hopes someone can help me.

Some notes:
- when I save my JSON to a file and then try to manually upload this via the MapRoulette UI (`Edit Challenge -> Change Name or Data Source -> upload GeoJSON file`), it works with no problems whatsoever (no errors, I can start tasks and they work as expected).
- I'm working with a Tag Fix challenge, my JSON is therefore in line-by-line format, as mentioned on [learn.maproulette.org](https://learn.maproulette.org/documentation/line-by-line-geojson/)
- when I use the web-based API test on [swagger](https://maproulette.org/docs/swagger-ui/index.html?url=/assets/swagger.json&docExpansion=none#/Challenge/addTasksToChallengeFromFile), curl receives a `Missing boundary header` error. This is also true for curl on my local machine. I receive the same error whether I use the afforementioned JSON (that works in MR UI) or some (valid as well as invalid JSON) bogus data.

Here's a gist with example data: https://gist.github.com/rYR79435/08f2835ae1876c1e8c5ed8968cce208e